### PR TITLE
Gist preview & access token

### DIFF
--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -91,6 +91,7 @@ export default class Toolbar extends React.Component {
       />
       <ExportModal
         mapStyle={this.props.mapStyle}
+        onStyleChanged={this.props.onStyleChanged}
         isOpen={this.state.isOpen.export}
         onOpenToggle={this.toggleModal.bind(this, 'export')}
       />

--- a/src/components/inputs/CheckboxInput.jsx
+++ b/src/components/inputs/CheckboxInput.jsx
@@ -17,7 +17,9 @@ class CheckboxInput extends React.Component {
         checked={this.props.value}
       />
       <div className="maputnik-checkbox-box">
-        <svg className="maputnik-checkbox-icon" viewBox='0 0 32 32'>
+        <svg style={{
+            display: this.props.value ? 'inline' : 'none'
+          }} className="maputnik-checkbox-icon" viewBox='0 0 32 32'>
           <path d='M1 14 L5 10 L13 18 L27 4 L31 8 L13 26 z' />
         </svg>
       </div>

--- a/src/components/inputs/StringInput.jsx
+++ b/src/components/inputs/StringInput.jsx
@@ -27,7 +27,7 @@ class StringInput extends React.Component {
       placeholder={this.props.default}
       onChange={e => this.setState({ value: e.target.value })}
       onBlur={() => {
-        if(this.state.value) this.props.onChange(this.state.value)
+        if(this.state.value!==this.props.value) this.props.onChange(this.state.value)
       }}
     />
   }

--- a/src/components/modals/ExportModal.jsx
+++ b/src/components/modals/ExportModal.jsx
@@ -156,7 +156,8 @@ class Gist extends React.Component {
         value={this.state.preview}
         name='gist-style-preview'
         onChange={this.onPreviewChange.bind(this)}
-      /> including preview
+      />
+      <span> Include preview</span>
       {this.state.preview ?
           <div>
             <InputBlock
@@ -165,7 +166,7 @@ class Gist extends React.Component {
                   value={this.props.mapStyle.metadata['maputnik:openmaptiles_access_token']}
                   onChange={this.changeMetadataProperty.bind(this, "maputnik:openmaptiles_access_token")}/>
             </InputBlock>
-            <a target="_blank" href="https://openmaptiles.com/hosting/">Get access token for free</a>
+            <a target="_blank" href="https://openmaptiles.com/hosting/">Get your free access token</a>
           </div>
       : null}
       {this.renderLatestGist()}

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -72,3 +72,7 @@ label:hover {
     clear: both;
   }
 }
+
+a {
+  color: white;
+}

--- a/src/styles/_export.scss
+++ b/src/styles/_export.scss
@@ -1,0 +1,5 @@
+.maputnik-export-gist {
+  label.maputnik-checkbox-wrapper {
+    display: inline-block;
+  }
+}

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -181,3 +181,19 @@
   margin-right: $margin-3;
   float: right;
 }
+
+//EXPORT MODAL
+.maputnik-export-gist {
+  .maputnik-input-block {
+    margin-left: 0;
+    margin-right: 0;
+
+    label {
+      vertical-align: middle;
+    }
+  }
+  font-size: $font-size-6;
+  span {
+    color: $color-lowgray;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -27,6 +27,7 @@ $toolbar-height: 40px;
 @import 'picker';
 @import 'toolbar';
 @import 'modal';
+@import 'export';
 @import 'layout';
 @import 'layer';
 @import 'input';


### PR DESCRIPTION
When saving to Gist, user can choose if he wants a preview. If so, he needs to add access token that can be generated for free from the link below the input. It is the same access token from style settings.

In this PR, I changed also behaviour of two general components:
fab004cdfe4de1446074fd60e50b1d775a8d26d7 I did this because it did not call onChange listener if new value was empty string.
3b7fb7ae75c88f22bd0489a00d6fd5261618ebee I did this because it CheckBox always showed "check" icon despite being true or false.

@lukasmartinelli please check two mentioned commits carefully.