### PR TITLE
Update react-height peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-color": "^2.10.0",
     "react-dom": "^15.4.0",
     "react-file-reader-input": "^1.1.0",
-    "react-height": "^2.1.1",
+    "react-height": "^3.0.0",
     "react-icon-base": "^2.0.4",
     "react-icons": "^2.2.1",
     "react-motion": "^0.4.7",


### PR DESCRIPTION
This should hopefully make PRs #133 and #134 pass again. Note that https://github.com/nkbt/react-collapse/commit/24631961919e26d852120262b0cc2180e9c33ea8 seems to be the commit that caused our builds to fail.