### PR TITLE
Update react-collapse to ^4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-addons-pure-render-mixin": "^15.4.0",
     "react-autocomplete": "^1.4.0",
     "react-codemirror": "^0.3.0",
-    "react-collapse": "^2.3.3",
+    "react-collapse": "^4.0.2",
     "react-color": "^2.10.0",
     "react-dom": "^15.4.0",
     "react-file-reader-input": "^1.1.0",


### PR DESCRIPTION
This should fix the ongoing CI failures when running npm 4.

As far as I can tell, this version update does not cause any issues building or running the editor.