### PR TITLE
Improve autocomplete styling

### DIFF
--- a/src/styles/_input.scss
+++ b/src/styles/_input.scss
@@ -122,7 +122,8 @@
   &-menu {
     border: none;
     padding: 2px 0;
-    position: fixed;
+    margin-right: 10px;
+    position: absolute;
     overflow: auto;
     max-height: 50%;
     background: $color-gray;


### PR DESCRIPTION
Use "position: absolute" so that autocomplete follows the field when you scroll.
Match autocomplete width with element width (accounting for padding)

Previously, the autocomplete dialog would appear below the field (e.g. font) and not move if you scrolled the symbol-layer edit window to a different position. This change makes it so the autocomplete dialog follows the field when you scroll. There are also some changes to width to ensure it matches the width of the input field.