### PR TITLE
Move babel config out of package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/package.json
+++ b/package.json
@@ -53,15 +53,6 @@
     "request": "^2.79.0",
     "url": "^0.11.0"
   },
-  "babel": {
-    "presets": [
-      "es2015",
-      "react"
-    ],
-    "plugins": [
-      "transform-object-rest-spread"
-    ]
-  },
   "jshintConfig": {
     "esversion": 6
   },


### PR DESCRIPTION
When using maputnik as a dependency in another project (e.g. to use the LayerEditor component), webpack doesn't read the babel config. Webpack does read it if we put it in a ```.babelrc``` file instead