### PR TITLE
Prevent warning for ColorField

### DIFF
--- a/src/components/fields/ColorField.jsx
+++ b/src/components/fields/ColorField.jsx
@@ -91,7 +91,7 @@ class ColorField extends React.Component {
     </div>
 
     var swatchStyle = {
-      "background-color": this.props.value
+      backgroundColor: this.props.value
     };
 
     return <div className="maputnik-color-wrapper">


### PR DESCRIPTION
This gets rid of a warning for ColorField:

```
warning.js:36 Warning: Unsupported style property background-color. Did you mean backgroundColor? Check the render method of `ColorField`.
```