### PR TITLE
Add transform-class-properties plugin to babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
 }


### PR DESCRIPTION
This is a follow-up to #144 on the current code base I get (this PR fixes that):

```
ERROR in ./~/maputnik/src/components/layers/LayerEditor.jsx
Module build failed: SyntaxError: Unexpected token (45:19)

  43 | /** Layer editor supporting multiple types of layers. */
  44 | export default class LayerEditor extends React.Component {
> 45 |   static propTypes = {
     |                    ^
  46 |     layer: React.PropTypes.object.isRequired,
  47 |     sources: React.PropTypes.object,
  48 |     vectorLayers: React.PropTypes.object,
```