### PR TITLE
Make sure propTypes accept what gets passed in

### DIFF
--- a/src/components/fields/SpecField.jsx
+++ b/src/components/fields/SpecField.jsx
@@ -43,6 +43,7 @@ export default class SpecField extends React.Component {
       React.PropTypes.string,
       React.PropTypes.number,
       React.PropTypes.array,
+      React.PropTypes.bool
     ]),
     /** Override the style of the field */
     style: React.PropTypes.object,

--- a/src/components/fields/ZoomSpecField.jsx
+++ b/src/components/fields/ZoomSpecField.jsx
@@ -31,6 +31,7 @@ export default class ZoomSpecProperty  extends React.Component {
       React.PropTypes.string,
       React.PropTypes.number,
       React.PropTypes.bool,
+      React.PropTypes.array
     ]),
   }
 


### PR DESCRIPTION
This gets rid of the propTypes warnings which you can encounter when using ```fill-antialias``` or ```fill-translate``` in a MapBox GL Style JSON document

@tbarsballe pointed out that because these props accept functions, so the current behaviour actually makes sense

closes #147