### PR TITLE
Added comments field doc and updated react-collapse to fix styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-addons-pure-render-mixin": "^15.4.0",
     "react-autocomplete": "^1.4.0",
     "react-codemirror": "^0.3.0",
-    "react-collapse": "^4.0.2",
+    "react-collapse": "^4.0.3",
     "react-color": "^2.10.0",
     "react-dom": "^15.4.0",
     "react-file-reader-input": "^1.1.0",

--- a/src/components/layers/CommentBlock.jsx
+++ b/src/components/layers/CommentBlock.jsx
@@ -10,7 +10,7 @@ class MetadataBlock extends React.Component {
   }
 
   render() {
-    return <InputBlock label={"Comments"}>
+    return <InputBlock label={"Comments"} doc={"Comments for the current layer. This is non-standard and not in the spec."}>
       <StringInput
         multi={true}
         value={this.props.value}


### PR DESCRIPTION
Added the missing doc tooltip on the comments field (which also fixes the styling issues). Also updated 'react-collapse' so the tooltip is now visible and not hidden by the `overflow: hidden` from the old version of react-collapse