### PR TITLE
Fixes logo styling in toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^0.34.0",
     "mapbox-gl-inspect": "^1.2.3",
+    "maputnik-design": "github:maputnik/design",
     "mousetrap": "^1.6.0",
     "ol-mapbox-style": "1.0.1",
     "openlayers": "^3.19.1",

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -16,7 +16,7 @@ import MdFontDownload from 'react-icons/lib/md/font-download'
 import HelpIcon from 'react-icons/lib/md/help-outline'
 import InspectionIcon from 'react-icons/lib/md/find-in-page'
 
-import logoImage from '../img/maputnik.png'
+import logoImage from 'maputnik-design/logos/logo-color.svg'
 import SettingsModal from './modals/SettingsModal'
 import ExportModal from './modals/ExportModal'
 import SourcesModal from './modals/SourcesModal'

--- a/src/styles/_toolbar.scss
+++ b/src/styles/_toolbar.scss
@@ -22,9 +22,8 @@
 
   img {
     width: 30px;
-    height: 30px;
     padding-right: $margin-2;
-    vertical-align: middle;
+    vertical-align: top;
   }
 }
 

--- a/test/specs/simple.js
+++ b/test/specs/simple.js
@@ -9,7 +9,7 @@ describe('maputnik', function() {
     browser.waitForExist(".maputnik-toolbar-link");
 
     var src = browser.getAttribute(".maputnik-toolbar-link img", "src");
-    assert.equal(src, config.baseUrl+'/img/maputnik.png');
+    assert.equal(src, config.baseUrl+'/img/logo-color.svg');
   });
 
 });


### PR DESCRIPTION
Fixes logo styling in the toolbar, the logo is no longer stretched. Also switched to the logo in [maputnik/design](https://github.com/maputnik/design).

Before

<img width="140" alt="before" src="https://user-images.githubusercontent.com/235915/31435188-ba87321e-ae76-11e7-924e-0d87f6e44eba.png">

After

<img width="178" alt="after" src="https://user-images.githubusercontent.com/235915/31435200-c0757dac-ae76-11e7-9fc4-619c1a763460.png">
