### PR TITLE
Fix insecure asset loading

### DIFF
--- a/src/config/styles.json
+++ b/src/config/styles.json
@@ -3,25 +3,25 @@
     "id": "klokantech-basic",
     "title": "Klokantech Basic",
     "url": "https://rawgit.com/openmaptiles/klokantech-basic-gl-style/master/style.json",
-    "thumbnail": "http://maputnik.com/thumbnails/klokantech-basic.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/klokantech-basic.png"
   },
   {
     "id": "dark-matter",
     "title": "Dark Matter",
     "url": "https://rawgit.com/openmaptiles/dark-matter-gl-style/master/style.json",
-    "thumbnail": "http://maputnik.com/thumbnails/dark-matter.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/dark-matter.png"
   },
   {
     "id": "positron",
     "title": "Positron",
     "url": "https://rawgit.com/openmaptiles/positron-gl-style/master/style.json",
-    "thumbnail": "http://maputnik.com/thumbnails/positron.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/positron.png"
   },
   {
     "id": "osm-bright",
     "title": "OSM Bright",
     "url": "https://rawgit.com/openmaptiles/osm-bright-gl-style/master/style.json",
-    "thumbnail": "http://maputnik.com/thumbnails/osm-bright.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/osm-bright.png"
   },
   {
     "id": "osm-liberty",
@@ -39,24 +39,24 @@
     "id": "mapbox-satellite",
     "title": "Mapbox Satellite",
     "url": "https://rawgit.com/mapbox/mapbox-gl-styles/master/styles/satellite-v9.json",
-    "thumbnail": "http://maputnik.com/thumbnails/mapbox-satellite.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/mapbox-satellite.png"
   },
   {
     "id": "mapbox-bright",
     "title": "Mapbox Bright",
     "url": "https://rawgit.com/mapbox/mapbox-gl-styles/master/styles/bright-v9.json",
-    "thumbnail": "http://maputnik.com/thumbnails/mapbox-bright.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/mapbox-bright.png"
   },
   {
     "id": "mapbox-basic",
     "title": "Mapbox Basic",
     "url": "https://rawgit.com/mapbox/mapbox-gl-styles/master/styles/basic-v9.json",
-    "thumbnail": "http://maputnik.com/thumbnails/mapbox-basic.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/mapbox-basic.png"
   },
   {
     "id": "tilezen",
     "title": "Tilezen",
     "url": "https://rawgit.com/lukasmartinelli/tilezen-gl-style/master/style.json",
-    "thumbnail": "http://maputnik.com/thumbnails/tilezen.png"
+    "thumbnail": "https://maputnik.github.io/thumbnails/tilezen.png"
   }
 ]

--- a/src/config/styles.json
+++ b/src/config/styles.json
@@ -52,11 +52,5 @@
     "title": "Mapbox Basic",
     "url": "https://rawgit.com/mapbox/mapbox-gl-styles/master/styles/basic-v9.json",
     "thumbnail": "https://maputnik.github.io/thumbnails/mapbox-basic.png"
-  },
-  {
-    "id": "tilezen",
-    "title": "Tilezen",
-    "url": "https://rawgit.com/lukasmartinelli/tilezen-gl-style/master/style.json",
-    "thumbnail": "https://maputnik.github.io/thumbnails/tilezen.png"
   }
 ]

--- a/src/config/tilesets.json
+++ b/src/config/tilesets.json
@@ -12,7 +12,7 @@
   "tilezen": {
     "type": "vector",
     "tiles": [
-      "http://tile.mapzen.com/mapzen/vector/v1/{layers}/{z}/{x}/{y}.pbf?api_key=mapzen-RVcyVL7"
+      "https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt?api_key=mapzen-RVcyVL7"
     ],
     "minZoom": 0,
     "maxZoom": 15,

--- a/src/config/tilesets.json
+++ b/src/config/tilesets.json
@@ -8,14 +8,5 @@
     "type": "vector",
     "url": "https://free.tilehosting.com/data/v3.json?key={key}",
     "title": "OpenMapTiles"
-  },
-  "tilezen": {
-    "type": "vector",
-    "tiles": [
-      "https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt?api_key=mapzen-RVcyVL7"
-    ],
-    "minZoom": 0,
-    "maxZoom": 15,
-    "title": "Mapzen Vector Tile Service"
   }
 }


### PR DESCRIPTION
Changes the HTTP paths for loading thumbnail images and one tile layer to HTTPS to avoid Mixed Content errors. Also closes #153, but it looks like there's a separate issue with the Tilezen style where it returns HTTP 401 unauthorized errors for the Mapbox fonts, so I'm guessing the API key for that style may be invalid here https://rawgit.com/lukasmartinelli/tilezen-gl-style/master/style.json