### PR TITLE
Assigning default function type from spec

### DIFF
--- a/src/components/fields/FunctionSpecField.jsx
+++ b/src/components/fields/FunctionSpecField.jsx
@@ -89,6 +89,16 @@ export default class FunctionSpecProperty  extends React.Component {
     this.props.onChange(this.props.fieldName, zoomFunc)
   }
 
+  getFieldFunctionType(fieldSpec) {
+    if (fieldSpec.function === "interpolated") {
+      return "exponential"
+    }
+    if (fieldSpec.type === "number") {
+      return "interval"
+    }
+    return "categorical"
+  }
+
   getDataFunctionTypes(functionType) {
     if (functionType === "interpolated") {
       return ["categorical", "interval", "exponential"]
@@ -131,6 +141,9 @@ export default class FunctionSpecProperty  extends React.Component {
   }
 
   renderDataProperty() {
+    if (typeof this.props.value.type === "undefined") {
+      this.props.value.type = this.getFieldFunctionType(this.props.fieldSpec)
+    }
     const dataFields = this.props.value.stops.map((stop, idx) => {
       const zoomLevel = stop[0].zoom
       const dataLevel = stop[0].value


### PR DESCRIPTION
Fixes some lingering issues from #161. I noticed that when I load a style where the type wasn't explicitly identified on a data driven style that it would default to `categorical`. Instead of this, if an uploaded style doesn't have a `type` property this checks the `fieldSpec` to determine what it should be.

According to the [style spec details on functions](https://www.mapbox.com/mapbox-gl-js/style-spec/#types-function), any property that supports `interpolated` must be numeric and defaults to `exponential`, and any property that is numeric and supports functions (checked elsewhere) must support `interval`. I'm using that logic in `getFieldFunctionType` to determine which to assign, and it's worked on styles I've tested for `exponential`, `interval`, and `categorical`