### PR TITLE
Disable polling by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ npm install
 npm start
 ```
 
-Build a production package for distribution.
+The build process will watch for changes to the filesystem, rebuild and autoreload the editor. However note this from the webpack-dev-server docs
+
+> webpack uses the file system to get notified of file changes. In some cases this does not work. For example, when using Network File System (NFS). Vagrant also has a lot of problems with this. 
+Snippet from <https://webpack.js.org/configuration/dev-server/#devserver-watchoptions->
+
+To enable polling add `export WEBPACK_DEV_SERVER_POLLING=1` to your enviroment.
 
 ```
 npm run build

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -46,8 +46,7 @@ module.exports = {
       // Disabled polling by default as it causes lots of CPU usage and hence drains laptop batteries. To enable polling add WEBPACK_DEV_SERVER_POLLING to your environment
       // See <https://webpack.js.org/configuration/watch/#watchoptions-poll> for details
       poll: (!!process.env.WEBPACK_DEV_SERVER_POLLING ? true : false),
-      watch: false,
-      ignored: /node_modules/
+      watch: false
     }
   },
   plugins: [

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -41,7 +41,14 @@ module.exports = {
     // serve index.html in place of 404 responses to allow HTML5 history
     historyApiFallback: true,
     port: PORT,
-    host: HOST
+    host: HOST,
+    watchOptions: {
+      // Disabled polling by default as it causes lots of CPU usage and hence drains laptop batteries. To enable polling add WEBPACK_DEV_SERVER_POLLING to your environment
+      // See <https://webpack.js.org/configuration/watch/#watchoptions-poll> for details
+      poll: (!!process.env.WEBPACK_DEV_SERVER_POLLING ? true : false),
+      watch: false,
+      ignored: /node_modules/
+    }
   },
   plugins: [
     new webpack.NoErrorsPlugin(),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "webpack --config config/webpack.production.config.js --progress --profile --colors",
     "test": "wdio config/wdio.conf.js",
     "test-watch": "wdio config/wdio.conf.js --watch",
-    "start": "webpack-dev-server --progress --profile --colors --watch-poll --config config/webpack.config.js",
+    "start": "webpack-dev-server --progress --profile --colors --config config/webpack.config.js",
     "lint": "eslint --ext js --ext jsx {src,test}",
     "lint-styles": "stylelint 'src/styles/*.scss'"
   },


### PR DESCRIPTION
I've disabled `webpack-dev-server` polling by default. Most users won't need this enabled and for those that don't require polling it was causing lots of CPU usage. Which was causing my cafe trips to work on maputnik to be cut short due to a drained battery  ☹️

This should be a better default for most users. I've also verified works inside a docker container just fine.