### PR TITLE
Catch invalid color

### DIFF
--- a/src/components/fields/ColorField.jsx
+++ b/src/components/fields/ColorField.jsx
@@ -50,16 +50,14 @@ class ColorField extends React.Component {
   }
 
   get color() {
-    let color = Color("rgb(255,255,255)");
-
     // Catch invalid color.
     try {
       return Color(this.props.value).rgb()
     }
     catch(err) {
       console.warn("Error parsing color: ", err);
+      return Color("rgb(255,255,255)");
     }
-    return color;
   }
 
   render() {

--- a/src/components/fields/ColorField.jsx
+++ b/src/components/fields/ColorField.jsx
@@ -50,7 +50,16 @@ class ColorField extends React.Component {
   }
 
   get color() {
-    return Color(this.props.value || '#fff').rgb()
+    let color = Color("rgb(255,255,255)");
+
+    // Catch invalid color.
+    try {
+      return Color(this.props.value).rgb()
+    }
+    catch(err) {
+      console.warn("Error parsing color: ", err);
+    }
+    return color;
   }
 
   render() {


### PR DESCRIPTION
If the color is invalid in the style it can cause the editor to stop rendering. This fixes that.

To reproduce try changing a color to something like `rgb(,0,0)` which will cause an error. If you now reload the editor it'll be stuck in a broken state. 