### PR TITLE
Added support for mapbox:// urls to fetchSources

### DIFF
--- a/config/webpack.loaders.js
+++ b/config/webpack.loaders.js
@@ -8,7 +8,7 @@ module.exports = [
   // We have to include this for access to `normalizeSourceURL`. We should
   // remove this ASAP, see <https://github.com/mapbox/mapbox-gl-js/issues/2416>
   {
-    test: /.*node_modules[\/\\]mapbox-gl[\/\\]src[\///]util[\/\\].*\.js/,
+    test: /.*node_modules[\/\\]mapbox-gl[\/\\]src[\/\\]util[\/\\].*\.js/,
     loader: 'babel-loader',
     query: {
       presets: ['env', 'react', 'flow'],

--- a/config/webpack.loaders.js
+++ b/config/webpack.loaders.js
@@ -4,6 +4,17 @@ module.exports = [
     exclude: /(node_modules|bower_components|public)/,
     loaders: ['react-hot-loader/webpack']
   },
+  // HACK: This is a massive hack and reaches into the mapbox-gl private API.
+  // We have to include this for access to `normalizeSourceURL`. We should
+  // remove this ASAP, see <https://github.com/mapbox/mapbox-gl-js/issues/2416>
+  {
+    test: /.*node_modules[\/\\]mapbox-gl[\/\\]src[\///]util[\/\\].*\.js/,
+    loader: 'babel-loader',
+    query: {
+      presets: ['env', 'react', 'flow'],
+      plugins: ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties'],
+    }
+  },
   {
     test: /\.jsx?$/,
     exclude: /(.*node_modules(?![\/\\]@mapbox[\/\\]mapbox-gl-style-spec)|bower_components|public)/,

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "base64-loader": "^1.0.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -203,7 +203,12 @@ export default class App extends React.Component {
       };
 
       if(!this.state.sources.hasOwnProperty(key) && val.type === "vector") {
-        const url = mapboxUtil.normalizeSourceURL(val.url, MapboxGl.accessToken);
+        let url = val.url;
+        try {
+          url = mapboxUtil.normalizeSourceURL(url, MapboxGl.accessToken);
+        } catch(err) {
+          console.warn("Failed to normalizeSourceURL: ", err);
+        }
 
         fetch(url)
           .then((response) => {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -21,6 +21,10 @@ import LayerWatcher from '../libs/layerwatcher'
 import tokens from '../config/tokens.json'
 import isEqual from 'lodash.isequal'
 
+import MapboxGl from 'mapbox-gl'
+import mapboxUtil from 'mapbox-gl/src/util/mapbox'
+
+
 function updateRootSpec(spec, fieldName, newValues) {
   return {
     ...spec,
@@ -199,7 +203,8 @@ export default class App extends React.Component {
       };
 
       if(!this.state.sources.hasOwnProperty(key) && val.type === "vector") {
-        const url = val.url;
+        const url = mapboxUtil.normalizeSourceURL(val.url, MapboxGl.accessToken);
+
         fetch(url)
           .then((response) => {
             return response.json();


### PR DESCRIPTION
This is a hack, but seems like it's generally pretty useful to be able to parse `mapbox://` urls. See comment in `config/webpack.loaders.js`

Fixes #224 