### PR TITLE
Updated mapbox-gl-inspect to v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7597,7 +7597,9 @@
       }
     },
     "mapbox-gl-inspect": {
-      "version": "github:orangemug/mapbox-gl-inspect#5af5114eea285b2259799c001b33076f86f8fe95",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl-inspect/-/mapbox-gl-inspect-1.3.0.tgz",
+      "integrity": "sha512-84qABwzuCenZz3oNF8vzqymE5dBoDhEkG5FUdPE2XFXaYabLo4lODRLReMYzeoNPn/4IJFUb9Qy3MN7lGG8CfA==",
       "requires": {
         "lodash.isequal": "4.5.0",
         "randomcolor": "0.4.4"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^0.44.1",
-    "mapbox-gl-inspect": "github:orangemug/mapbox-gl-inspect#fix/only-vector-sources",
+    "mapbox-gl-inspect": "^1.3.0",
     "maputnik-design": "github:maputnik/design",
     "mousetrap": "^1.6.1",
     "ol-mapbox-style": "^2.10.1",


### PR DESCRIPTION
Updated from personal fork/branch `orangemug/mapbox-gl-inspect#fix/only-vector-sources`