### PR TITLE
Use a fixed position for autocomplete menu

### DIFF
--- a/src/components/inputs/AutocompleteInput.jsx
+++ b/src/components/inputs/AutocompleteInput.jsx
@@ -54,7 +54,7 @@ class AutocompleteInput extends React.Component {
     >
       <Autocomplete
         menuStyle={{
-          position: "absolute",
+          position: "fixed",
           overflow: "auto",
           maxHeight: this.state.maxHeight
         }}


### PR DESCRIPTION
Fix regression introduced by https://github.com/maputnik/editor/pull/226

The autocomplete list was not displayed correctly.

Tested on ubuntu/chrome and mac/safari