### PR TITLE
Disable gist export

### DIFF
--- a/src/components/modals/ExportModal.jsx
+++ b/src/components/modals/ExportModal.jsx
@@ -258,7 +258,7 @@ class ExportModal extends React.Component {
         </Button>
       </div>
 
-      <div className="maputnik-modal-section">
+      <div className="maputnik-modal-section hide">
         <h4>Save style</h4>
         <Gist mapStyle={this.props.mapStyle} onStyleChanged={this.props.onStyleChanged}/>
       </div>

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -76,3 +76,7 @@ label:hover {
 a {
   color: white;
 }
+
+.hide {
+  display: none !important;
+}


### PR DESCRIPTION
Anonymous gists are no longer supported by GitHub. See <https://github.com/maputnik/editor/issues/269>

Disabling until we get GitHub auth working.