### PR TITLE
Added button to expand/collapse layer group

### DIFF
--- a/src/components/layers/Collapser.jsx
+++ b/src/components/layers/Collapser.jsx
@@ -15,7 +15,15 @@ export default class Collapser extends React.Component {
       height: 20,
       ...this.props.style,
     }
-    return this.props.isCollapsed ? <CollapseCloseIcon style={iconStyle}/> : <CollapseOpenIcon style={iconStyle} />
+
+    const ariaProps = {
+      "aria-hidden": true,
+      focusable: false
+    };
+
+    return this.props.isCollapsed
+      ? <CollapseCloseIcon {...ariaProps} style={iconStyle}/>
+      : <CollapseOpenIcon {...ariaProps} style={iconStyle} />
   }
 }
 

--- a/src/components/layers/LayerEditorGroup.jsx
+++ b/src/components/layers/LayerEditorGroup.jsx
@@ -14,14 +14,15 @@ export default class LayerEditorGroup extends React.Component {
 
   render() {
     return <div>
-      <div className="maputnik-layer-editor-group"
+      <button className="maputnik-layer-editor-group"
         data-wd-key={"layer-editor-group:"+this.props["data-wd-key"]}
+        aria-expanded={this.props.isActive}
         onClick={e => this.props.onActiveToggle(!this.props.isActive)}
       >
         <span>{this.props.title}</span>
         <span style={{flexGrow: 1}} />
         <Collapser isCollapsed={this.props.isActive} />
-      </div>
+      </button>
       <Collapse isOpened={this.props.isActive}>
         <div className="react-collapse-container">
           {this.props.children}

--- a/src/styles/_layer.scss
+++ b/src/styles/_layer.scss
@@ -114,6 +114,10 @@
 
 // FILTER EDITOR
 .maputnik-layer-editor-group {
+  display: flex;
+  width: 100%;
+  text-align: left;
+  border: none;
   font-weight: bold;
   font-size: $font-size-5;
   background-color: lighten($color-black, 2);


### PR DESCRIPTION
Improves accessibility my making layer expand/collapse keyboard accessible.

**Needs further research:** Should the whole element be a button or just the expand/collapse icon?