### PR TITLE
Color blindness emulation

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Mousetrap from 'mousetrap'
+import url from 'url'
 
 import MapboxGlMap from './map/MapboxGlMap'
 import OpenLayers3Map from './map/OpenLayers3Map'
@@ -71,6 +72,8 @@ export default class App extends React.Component {
       Debug.set("maputnik", "styleStore", this.styleStore);
     }
 
+    const queryObj = url.parse(window.location.href, true).query;
+
     this.state = {
       errors: [],
       infos: [],
@@ -80,6 +83,7 @@ export default class App extends React.Component {
       vectorLayers: {},
       inspectModeEnabled: false,
       spec: styleSpec.latest,
+      mapFilter: queryObj["color-blindness-emulation"],
     }
 
     this.layerWatcher = new LayerWatcher({
@@ -266,15 +270,25 @@ export default class App extends React.Component {
     const metadata = this.state.mapStyle.metadata || {}
     const renderer = metadata['maputnik:renderer'] || 'mbgljs'
 
+    let mapElement;
+
     // Check if OL3 code has been loaded?
     if(renderer === 'ol3') {
-      return <OpenLayers3Map {...mapProps} />
+      mapElement = <OpenLayers3Map {...mapProps} />
     } else {
-      return  <MapboxGlMap {...mapProps}
+      mapElement = <MapboxGlMap {...mapProps}
         inspectModeEnabled={this.state.inspectModeEnabled}
         highlightedLayer={this.state.mapStyle.layers[this.state.selectedLayerIndex]}
         onLayerSelect={this.onLayerSelect.bind(this)} />
     }
+
+    const elementStyle = {
+      "filter": `url('#${this.state.mapFilter}')`
+    };
+
+    return <div style={elementStyle}>
+      {mapElement}
+    </div>
   }
 
   onLayerSelect(layerId) {

--- a/src/template.html
+++ b/src/template.html
@@ -69,6 +69,87 @@
   </style>
 </head>
 <body>
+  <!-- TODO: Import dynamically -->
+  <!-- From <https://github.com/hail2u/color-blindness-emulation> -->
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1">
+    <defs>
+      <filter id="protanopia">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.567, 0.433, 0,     0, 0
+                  0.558, 0.442, 0,     0, 0
+                  0,     0.242, 0.758, 0, 0
+                  0,     0,     0,     1, 0"/>
+      </filter>
+      <filter id="protanomaly">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.817, 0.183, 0,     0, 0
+                  0.333, 0.667, 0,     0, 0
+                  0,     0.125, 0.875, 0, 0
+                  0,     0,     0,     1, 0"/>
+      </filter>
+      <filter id="deuteranopia">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.625, 0.375, 0,   0, 0
+                  0.7,   0.3,   0,   0, 0
+                  0,     0.3,   0.7, 0, 0
+                  0,     0,     0,   1, 0"/>
+      </filter>
+      <filter id="deuteranomaly">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.8,   0.2,   0,     0, 0
+                  0.258, 0.742, 0,     0, 0
+                  0,     0.142, 0.858, 0, 0
+                  0,     0,     0,     1, 0"/>
+      </filter>
+      <filter id="tritanopia">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.95, 0.05,  0,     0, 0
+                  0,    0.433, 0.567, 0, 0
+                  0,    0.475, 0.525, 0, 0
+                  0,    0,     0,     1, 0"/>
+      </filter>
+      <filter id="tritanomaly">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.967, 0.033, 0,     0, 0
+                  0,     0.733, 0.267, 0, 0
+                  0,     0.183, 0.817, 0, 0
+                  0,     0,     0,     1, 0"/>
+      </filter>
+      <filter id="achromatopsia">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.299, 0.587, 0.114, 0, 0
+                  0.299, 0.587, 0.114, 0, 0
+                  0.299, 0.587, 0.114, 0, 0
+                  0,     0,     0,     1, 0"/>
+      </filter>
+      <filter id="achromatomaly">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0.618, 0.320, 0.062, 0, 0
+                  0.163, 0.775, 0.062, 0, 0
+                  0.163, 0.320, 0.516, 0, 0
+                  0,     0,     0,     1, 0"/>
+      </filter>
+    </defs>
+  </svg>
+
   <div id="app">
     <div id="loader">Loading...</div>
   </div>


### PR DESCRIPTION
An initial attempt at adding 'color blindness emulation' to the editor. To use it add a query string param `color-blindness-emulation` with one of the following values. Note the links point to the branch build of the editor for testing.

 - [protanopia](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=protanopia)
 - [protanomaly](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=protanomaly)
 - [deuteranopia](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=deuteranopia)
 - [deuteranomaly](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=deuteranomaly)
 - [tritanopia](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=tritanopia)
 - [tritanomaly](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=tritanomaly)
 - [achromatopsia](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=achromatopsia)
 - [achromatomaly](https://482-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html?style=https://osm-liberty.lukasmartinelli.ch/style.json&color-blindness-emulation=achromatomaly)

This is the first stage, if it's correct we'll merge and work out a way to create a UI

_Note:_ Most of the credit goes to https://github.com/hail2u/color-blindness-emulation