### PR TITLE
Small bug fixes

### DIFF
--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -100,19 +100,23 @@ export default class Toolbar extends React.Component {
   render() {
     return <div className='maputnik-toolbar'>
       <div className="maputnik-toolbar__inner">
-        <ToolbarLink
-          tabIndex="2"
-          href={"https://github.com/maputnik/editor"}
-          className="maputnik-toolbar-logo"
+        <div
+          className="maputnik-toolbar-logo-container"
         >
-          <a tabIndex="1" className="maputnik-toolbar-skip" href="#skip-menu">
+          <a className="maputnik-toolbar-skip" href="#skip-menu">
             Skip navigation
           </a>
-          <img src={logoImage} alt="Maputnik" />
-          <h1>Maputnik
-            <span className="maputnik-toolbar-version">v{pkgJson.version}</span>
-          </h1>
-        </ToolbarLink>
+          <a
+            href="https://github.com/maputnik/editor"
+            target="_blank"
+            className="maputnik-toolbar-logo"
+          >
+            <img src={logoImage} alt="Maputnik" />
+            <h1>Maputnik
+              <span className="maputnik-toolbar-version">v{pkgJson.version}</span>
+            </h1>
+          </a>
+        </div>
         <div className="maputnik-toolbar__actions">
           <ToolbarAction wdKey="nav:open" onClick={this.props.onToggleModal.bind(this, 'open')}>
             <OpenIcon />

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -108,6 +108,7 @@ export default class Toolbar extends React.Component {
           </a>
           <a
             href="https://github.com/maputnik/editor"
+            rel="noopener noreferrer"
             target="_blank"
             className="maputnik-toolbar-logo"
           >

--- a/src/components/inputs/SelectInput.jsx
+++ b/src/components/inputs/SelectInput.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 class SelectInput extends React.Component {
   static propTypes = {
     value: PropTypes.string.isRequired,
-    "data-wd-key": PropTypes.string.isRequired,
+    "data-wd-key": PropTypes.string,
     options: PropTypes.array.isRequired,
     style: PropTypes.object,
     onChange: PropTypes.func.isRequired,

--- a/src/components/layers/LayerTypeBlock.jsx
+++ b/src/components/layers/LayerTypeBlock.jsx
@@ -8,7 +8,7 @@ import SelectInput from '../inputs/SelectInput'
 class LayerTypeBlock extends React.Component {
   static propTypes = {
     value: PropTypes.string.isRequired,
-    wdKey: PropTypes.string.isRequired,
+    wdKey: PropTypes.string,
     onChange: PropTypes.func.isRequired,
   }
 

--- a/src/styles/_react-collapse.scss
+++ b/src/styles/_react-collapse.scss
@@ -1,5 +1,8 @@
 // See <https://github.com/nkbt/react-collapse/commit/4f4fbce7c6c07b082dc62062338c9294c656f9df>
 .react-collapse-container {
-  position: relative;
-  overflow: hidden;
+  display: flex;
+
+  > * {
+    flex: 1;
+  }
 }

--- a/src/styles/_toolbar.scss
+++ b/src/styles/_toolbar.scss
@@ -9,7 +9,13 @@
   background-color: $color-black;
 }
 
+.maputnik-toolbar-logo-container {
+  position: relative;
+}
+
 .maputnik-toolbar-logo {
+  text-decoration: none;
+  display: block;
   flex: 0 0 180px;
   width: 180px;
   text-align: left;
@@ -21,6 +27,7 @@
 
   h1 {
     display: inline;
+    line-height: 26px;
   }
 
   img {
@@ -51,9 +58,7 @@
 }
 
 .maputnik-toolbar-version {
-  position: absolute;
   font-size: 10px;
-  bottom: -2px;
   margin-left: 4px;
   white-space: nowrap;
 }


### PR DESCRIPTION
 - Logo DOM sctrucutre now valid, no longer `<a/>` within `</a>`
 - `data-wd-key` not longer required
 - `maputnik-doc-popup` not longer hidden by LayerEditor accordion