### PR TITLE
Fixed <LayerEditor/> overflow issues

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -1,6 +1,6 @@
 //SCROLLING
 .maputnik-scroll-container {
-  overflow-x: visible;
+  overflow-x: hidden;
   overflow-y: scroll;
   bottom: 0;
   left: 0;

--- a/src/styles/_react-collapse.scss
+++ b/src/styles/_react-collapse.scss
@@ -1,6 +1,7 @@
 // See <https://github.com/nkbt/react-collapse/commit/4f4fbce7c6c07b082dc62062338c9294c656f9df>
 .react-collapse-container {
   display: flex;
+  max-width: 100%;
 
   > * {
     flex: 1;


### PR DESCRIPTION
The contents of the JSON editor could cause <LayerEditor/> to overflow.