### PR TITLE
Prevent bounce scroll on <body/>

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -18,6 +18,11 @@ html {
   box-sizing: border-box;
 }
 
+body {
+  // The UI is 100% height so prevent bounce scroll on OSX
+  overflow: hidden;
+}
+
 *,
 *::before,
 *::after {


### PR DESCRIPTION
The UI is 100% height so prevent bounce scroll on OSX