### PR TITLE
Disable survey in test runner

### DIFF
--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -13,6 +13,9 @@ describe('maputnik', function() {
       "geojson:example",
       "raster:raster"
     ]));
+    browser.execute(function() {
+      localStorage.setItem("survey", true);
+    });
     browser.waitForExist(".maputnik-toolbar-link");
     browser.flushReactUpdates();
   });


### PR DESCRIPTION
The survey popup was causing the tests to fail.

Also I forgot that node v8 build is the only runner that runs the UI tests, so that build wasn't just being flakey.... ooops!