### PR TITLE
find correct zoom attribute in spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5654,8 +5654,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
@@ -5848,9 +5848,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
           }
         },
         "fs.realpath": {
@@ -5933,8 +5933,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "has-unicode": {
@@ -5987,7 +5987,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
@@ -6027,7 +6027,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -6066,14 +6066,14 @@
           "version": "2.1.15",
           "bundled": true,
           "requires": {
-            "mime-db": "~1.27.0"
+            "mime-db": "1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
@@ -6115,8 +6115,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
@@ -6166,8 +6166,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {

--- a/src/components/fields/_FunctionButtons.jsx
+++ b/src/components/fields/_FunctionButtons.jsx
@@ -16,7 +16,7 @@ export default class FunctionButtons extends React.Component {
 
   render() {
     let makeZoomButton, makeDataButton
-    if (this.props.fieldSpec['zoom-function']) {
+    if (this.props.fieldSpec.expression.parameters.includes('zoom')) {
       makeZoomButton = <Button
         className="maputnik-make-zoom-function"
         onClick={this.props.onZoomClick}


### PR DESCRIPTION
This fixes #356, which was caused by a change in `mapbox-style-spec`.

The code was checking for the existence of `zoom-function` in the spec that was passed down, and would add the Σ icon and button for adding zoom-based styles if it existed.

This was recently changed, specs now have the following property:
```
"expression": {
  "interpolated": false,
  "parameters": [
      "zoom"
  ]
```
