### PR TITLE
Update tilehosting URL

### DIFF
--- a/src/config/tilesets.json
+++ b/src/config/tilesets.json
@@ -1,7 +1,7 @@
 {
   "openmaptiles": {
     "type": "vector",
-    "url": "https://free.tilehosting.com/data/v3.json?key={key}",
+    "url": "https://maps.tilehosting.com/data/v3.json?key={key}",
     "title": "OpenMapTiles"
   },
   "thunderforest_transport": {


### PR DESCRIPTION
To prevent confusion - `free` is working (redirected to `maps`), but `maps` is what Maptiler Cloud shows as URL in the dataset settings.