### PR TITLE
Stop autocomplete crashing the editor

### DIFF
--- a/src/components/inputs/AutocompleteInput.jsx
+++ b/src/components/inputs/AutocompleteInput.jsx
@@ -69,7 +69,7 @@ class AutocompleteInput extends React.Component {
         getItemValue={(item) => item[0]}
         onSelect={v => this.props.onChange(v)}
         onChange={(e, v) => this.props.onChange(v)}
-        shouldItemRender={(item, value) => {
+        shouldItemRender={(item, value="") => {
           return item[0].toLowerCase().indexOf(value.toLowerCase()) > -1
         }}
         renderItem={(item, isHighlighted) => (

--- a/src/components/inputs/AutocompleteInput.jsx
+++ b/src/components/inputs/AutocompleteInput.jsx
@@ -70,7 +70,9 @@ class AutocompleteInput extends React.Component {
         onSelect={v => this.props.onChange(v)}
         onChange={(e, v) => this.props.onChange(v)}
         shouldItemRender={(item, value="") => {
-          return item[0].toLowerCase().indexOf(value.toLowerCase()) > -1
+          if (typeof(value) === "string") {
+            return item[0].toLowerCase().indexOf(value.toLowerCase()) > -1
+          }
         }}
         renderItem={(item, isHighlighted) => (
           <div


### PR DESCRIPTION
Autocomplete was crashing the editor when an unexpected value was encountered. Mapbox GL expressions we're making their way into the `value` in the `shouldItemRender` function