### PR TITLE
Use GitHub Pages for OSM Liberty

### DIFF
--- a/src/config/styles.json
+++ b/src/config/styles.json
@@ -26,8 +26,8 @@
   {
     "id": "osm-liberty",
     "title": "OSM Liberty",
-    "url": "https://cdn.jsdelivr.net/gh/maputnik/osm-liberty@07c0d7dc4e266e244d7f4a7017ad96fd61bc1bf4/style.json",
-    "thumbnail": "https://cdn.rawgit.com/maputnik/osm-liberty/gh-pages/thumbnail.png"
+    "url": "https://maputnik.github.io/osm-liberty/style.json",
+    "thumbnail": "https://maputnik.github.io/osm-liberty/thumbnail.png"
   },
   {
     "id": "empty-style",


### PR DESCRIPTION
GitHub Pages is available for OSM Liberty, so we could use it instead of jsdelivr.net for the style URL (no need to update the URL if the style changes).

Also updated the thumbnail URL.