### PR TITLE
Remove node v9 from appveyor and update readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,11 @@ jobs:
       - image: node:10
     working_directory: ~/repo-linux-node-v10
     steps: *build-steps
+  build-linux-node-v11:
+    docker:
+      - image: node:11
+    working_directory: ~/repo-linux-node-v11
+    steps: *build-steps
   build-osx-node-v6:
     macos:
       xcode: "9.0"
@@ -89,6 +94,14 @@ jobs:
         - brew install node@10
     working_directory: ~/repo-osx-node-v10
     steps: *build-steps
+  build-osx-node-v11:
+    macos:
+      xcode: "9.0"
+    dependencies:
+      override:
+        - brew install node@11
+    working_directory: ~/repo-osx-node-v11
+    steps: *build-steps
 
 workflows:
   version: 2
@@ -97,7 +110,9 @@ workflows:
       - build-linux-node-v6
       - build-linux-node-v8
       - build-linux-node-v10
+      - build-linux-node-v11
       - build-osx-node-v6
       - build-osx-node-v8
       - build-osx-node-v10
+      - build-osx-node-v11
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,6 @@ jobs:
       - image: node:10
     working_directory: ~/repo-linux-node-v10
     steps: *build-steps
-  build-linux-node-v11:
-    docker:
-      - image: node:11
-    working_directory: ~/repo-linux-node-v11
-    steps: *build-steps
   build-osx-node-v6:
     macos:
       xcode: "9.0"
@@ -94,14 +89,6 @@ jobs:
         - brew install node@10
     working_directory: ~/repo-osx-node-v10
     steps: *build-steps
-  build-osx-node-v11:
-    macos:
-      xcode: "9.0"
-    dependencies:
-      override:
-        - brew install node@11
-    working_directory: ~/repo-osx-node-v11
-    steps: *build-steps
 
 workflows:
   version: 2
@@ -110,9 +97,7 @@ workflows:
       - build-linux-node-v6
       - build-linux-node-v8
       - build-linux-node-v10
-      - build-linux-node-v11
       - build-osx-node-v6
       - build-osx-node-v8
       - build-osx-node-v10
-      - build-osx-node-v11
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ A free and open visual editor for the [Mapbox GL styles](https://www.mapbox.com/
 targeted at developers and map designers.
 
 - :link: Design your maps online at **<https://maputnik.github.io/editor/>** (all in local storage)
-- :link: Use the [Maputnik CLI](https://github.com/maputnik/editor/wiki/Maputnik-CLI) for local style development
 
 Mapbox has built one of the best and most amazing OSS ecosystems. A key component to ensure its longevity and independance is an OSS map designer.
 
@@ -40,10 +39,7 @@ The documentation can be found in the [Wiki](https://github.com/maputnik/editor/
 
 Maputnik is written in ES6 and is using [React](https://github.com/facebook/react) and [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/).
 
-We ensure building and developing Maputnik works with
-
-- Linux, OSX and Windows
-- Node >4
+We ensure building and developing Maputnik works with the [current active LTS and above](https://github.com/nodejs/Release#release-schedule).
 
 Install the deps, start the dev server and open the web browser on `http://localhost:8888/`.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The documentation can be found in the [Wiki](https://github.com/maputnik/editor/
 
 Maputnik is written in ES6 and is using [React](https://github.com/facebook/react) and [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/).
 
-We ensure building and developing Maputnik works with the [current active LTS and above](https://github.com/nodejs/Release#release-schedule).
+We ensure building and developing Maputnik works with the [current active LTS Node.js version and above](https://github.com/nodejs/Release#release-schedule).
 
 Install the deps, start the dev server and open the web browser on `http://localhost:8888/`.
 
@@ -75,7 +75,7 @@ For testing we use [webdriverio](http://webdriver.io) and [selenium-standalone](
 
 [selenium-standalone](https://github.com/vvo/selenium-standalone) starts a server that will launch browsers on your local machine. We use chrome so you **must** have chrome installed on your machine.
 
-Now open and terminal and run the following. This will install the drivers on your local machine
+Now open a terminal and run the following. This will install the drivers on your local machine
 
 ```
 ./node_modules/.bin/selenium-standalone install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "9"
     - nodejs_version: "10"
+    - nodejs_version: "11"
 platform:
   - x86
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,7 @@ image: Visual Studio 2017
 environment:
   matrix:
     - nodejs_version: "8"
-    - nodejs_version: "9"
     - nodejs_version: "10"
-    - nodejs_version: "11"
 platform:
   - x86
   - x64


### PR DESCRIPTION
- Closes #445. 

- Removes the part regarding the Maputnik CLI. We could add it again if it would be available again in the future (maputnik/editor#360).