### PR TITLE
Update tests for style settings modal

### DIFF
--- a/test/functional/modals/index.js
+++ b/test/functional/modals/index.js
@@ -171,14 +171,14 @@ describe("modals", function() {
       assert.equal(styleObj.metadata["maputnik:openmaptiles_access_token"], apiKey);
     })
 
-    it.skip("style renderer", function() {
+    it("style renderer", function() {
       var selector = wd.$("modal-settings.maputnik:renderer");
-      browser.selectByValue(selector, "ol3");
+      browser.selectByValue(selector, "ol");
       browser.click(wd.$("modal-settings.name"))
       browser.flushReactUpdates();
 
       var styleObj = helper.getStyleStore(browser);
-      assert.equal(styleObj.metadata["maputnik:renderer"], "ol3");
+      assert.equal(styleObj.metadata["maputnik:renderer"], "ol");
     })
   })
 

--- a/test/functional/modals/index.js
+++ b/test/functional/modals/index.js
@@ -161,7 +161,7 @@ describe("modals", function() {
       })
     })
 
-    it("open map tiles access token", function() {
+    it("maptiler access token", function() {
       var apiKey = "testing123";
       browser.setValueSafe(wd.$("modal-settings.maputnik:openmaptiles_access_token"), apiKey);
       browser.click(wd.$("modal-settings.name"))
@@ -169,6 +169,16 @@ describe("modals", function() {
 
       var styleObj = helper.getStyleStore(browser);
       assert.equal(styleObj.metadata["maputnik:openmaptiles_access_token"], apiKey);
+    })
+
+    it("thunderforest access token", function() {
+      var apiKey = "testing123";
+      browser.setValueSafe(wd.$("modal-settings.maputnik:thunderforest_access_token"), apiKey);
+      browser.click(wd.$("modal-settings.name"))
+      browser.flushReactUpdates();
+
+      var styleObj = helper.getStyleStore(browser);
+      assert.equal(styleObj.metadata["maputnik:thunderforest_access_token"], apiKey);
     })
 
     it("style renderer", function() {


### PR DESCRIPTION
- Add test for Thunderforest access token. 
- Style renderer: It was skipped and now, after https://github.com/maputnik/editor/pull/397, could be used again.