### PR TITLE
Increase more-menu icon size, broken by react-icons update

### DIFF
--- a/src/styles/_layer.scss
+++ b/src/styles/_layer.scss
@@ -195,6 +195,11 @@
 .more-menu {
   position: relative;
 
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+
   &__menu {
     position: absolute;
     z-index: 9999;


### PR DESCRIPTION
Before
<img width="260" alt="screen shot 2018-10-31 at 08 24 23" src="https://user-images.githubusercontent.com/235915/47775026-7d71d100-dce6-11e8-8418-531b2f9cda19.png">

After
<img width="245" alt="screen shot 2018-10-31 at 08 23 30" src="https://user-images.githubusercontent.com/235915/47775024-7a76e080-dce6-11e8-9b40-453671ddb992.png">


Demo: <https://1175-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html#0.35/0/0>