### PR TITLE
Style layer which is dragged

### DIFF
--- a/src/components/layers/LayerList.jsx
+++ b/src/components/layers/LayerList.jsx
@@ -46,7 +46,7 @@ class LayerListContainer extends React.Component {
     areAllGroupsExpanded: false,
     isOpen: {
       add: false,
-    } 
+    }
   }
 
   toggleModal(modalName) {
@@ -66,12 +66,12 @@ class LayerListContainer extends React.Component {
     this.groupedLayers().forEach(layers => {
       const groupPrefix = layerPrefix(layers[0].id)
       const lookupKey = [groupPrefix, idx].join('-')
-      
+
 
       if (layers.length > 1) {
         newGroups[lookupKey] = this.state.areAllGroupsExpanded
       }
-      
+
       layers.forEach((layer) => {
         idx += 1
       })
@@ -204,6 +204,7 @@ export default class LayerList extends React.Component {
   render() {
     return <LayerListContainerSortable
       {...this.props}
+      helperClass='sortableHelper'
       onSortEnd={this.props.onMoveLayer.bind(this)}
       useDragHandle={true}
     />

--- a/src/styles/_layer.scss
+++ b/src/styles/_layer.scss
@@ -234,3 +234,10 @@
     min-width: 28px;
   }
 }
+
+// Clone of the element which is sorted
+.sortableHelper {
+  font-family: $font-family;
+  z-index: 9999;
+  border: none;
+}


### PR DESCRIPTION
When dragging a layer, there are the following issues:

- The dragged layer changes its font (not Roboto anymore).
- Sometimes the dragged layer is rendered behind other layers/groups.

This PR fixes these issues ([background information](https://github.com/clauderic/react-sortable-hoc#item-disappearing-when-sorting--css-issues)).

Also removes the border (= the underline) while dragging, it is hard to spot anyway and sometimes looks weird.

Demo: https://829-67726921-gh.circle-artifacts.com/0/artifacts/build/index.html