### PR TITLE
make docker simpler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ WORKDIR ${HOME}
 RUN npm install -d --dev
 RUN npm run build
 
-CMD npm run start -- --host 0.0.0.0
+WORKDIR ${HOME}/build/build
+CMD python -m SimpleHTTPServer 8888


### PR DESCRIPTION
assets of frontend is built by the last `RUN`,
so we just need to host the built assets.
in node, python is required, so use python simple server to do this.