### PR TITLE
Set MIME type for RTL blob

### DIFF
--- a/src/libs/mapbox-rtl.js
+++ b/src/libs/mapbox-rtl.js
@@ -3,9 +3,9 @@ import MapboxGl from 'mapbox-gl'
 // Load mapbox-gl-rtl-text using object urls without needing http://localhost for AJAX.
 const data = require("raw-loader?mimetype=text/javascript!@mapbox/mapbox-gl-rtl-text/mapbox-gl-rtl-text.js");
 
-const blob = new window.Blob([data]);
-const objectUrl = window.URL.createObjectURL(blob, {
+const blob = new window.Blob([data], {
   type: "text/javascript"
 });
+const objectUrl = window.URL.createObjectURL(blob);
 
 MapboxGl.setRTLTextPlugin(objectUrl);


### PR DESCRIPTION
Fixes the Chrome deprecation notice:

![image](https://user-images.githubusercontent.com/20856381/48976577-42b34c80-f08a-11e8-8e91-b70c5d67992c.png)

Demo: https://964-67726921-gh.circle-artifacts.com/0/artifacts/build/index.html