### PR TITLE
Use StringInput for 'formatted' field type

### DIFF
--- a/src/components/fields/SpecField.jsx
+++ b/src/components/fields/SpecField.jsx
@@ -81,6 +81,7 @@ export default class SpecField extends React.Component {
               options={options}
             />
           }
+        case 'formatted':
         case 'string':
           if(iconProperties.indexOf(this.props.fieldName) >= 0) {
             return <IconInput


### PR DESCRIPTION
Fixes #481 - this is just a hotfix, a more complete fix would need to add support for dynamically adding/editing format parts, as in [this example style](https://github.com/mapbox/mapbox-gl-js/blob/master/test/integration/render-tests/text-field/formatted-line/style.json)