### PR TITLE
IconInput value type should be string, not array

### DIFF
--- a/src/components/inputs/IconInput.jsx
+++ b/src/components/inputs/IconInput.jsx
@@ -5,7 +5,7 @@ import AutocompleteInput from './AutocompleteInput'
 
 class IconInput extends React.Component {
   static propTypes = {
-    value: PropTypes.array,
+    value: PropTypes.string,
     icons: PropTypes.array,
     style: PropTypes.object,
     onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes the following warning:

```
Warning: Failed prop type: Invalid prop `value` of type `string` supplied to `IconInput`, expected `array`.
    in IconInput (created by SpecField)
    in SpecField (created by SpecProperty)
    in div (created by InputBlock)
    in div (created by InputBlock)
    in InputBlock (created by SpecProperty)
    in SpecProperty (created by FunctionSpecProperty)
    in div (created by FunctionSpecProperty)
    in FunctionSpecProperty (created by PropertyGroup)
    in div (created by PropertyGroup)
    in PropertyGroup (created by LayerEditor)
    in div (created by LayerEditorGroup)
    in div (created by Motion)
    in div (created by Motion)
    in Motion (created by Collapse)
    in Collapse (created by UnmountClosed)
    in UnmountClosed (created by CollapseAlt)
    in CollapseAlt (created by LayerEditorGroup)
    in div (created by LayerEditorGroup)
    in LayerEditorGroup (created by LayerEditor)
    in div (created by LayerEditor)
    in LayerEditor (created by App)
    in div (created by ScrollContainer)
    in ScrollContainer (created by AppLayout)
    in div (created by AppLayout)
    in div (created by AppLayout)
    in AppLayout (created by App)
    in App
```