### PR TITLE
Use node:10-slim for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM node:10
+FROM node:10-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    python \
+ && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8888
 


### PR DESCRIPTION
Use `node:10-slim` instead of `node:10`.

This decreases the image size (`master`) from 1.22 GB -> 552 MB.