### PR TITLE
Firefox scrollbar styling

### DIFF
--- a/src/styles/_scrollbar.scss
+++ b/src/styles/_scrollbar.scss
@@ -12,4 +12,8 @@ div:not(.maputnik-toolbar__actions) {
     padding-left: 2px;
     padding-right: 2px;
   }
+  
+  // Styling for Firefox
+  scrollbar-width: thin;
+  scrollbar-color: #666 #26282e;
 }


### PR DESCRIPTION
Since Firefox 64 the following CSS properties are available:
https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width
https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color


**Before:**

![auswahl_545](https://user-images.githubusercontent.com/20856381/53797151-e2a82e00-3f35-11e9-8a57-45e9c6907a71.png)

**This PR:**

![auswahl_546](https://user-images.githubusercontent.com/20856381/53797169-ea67d280-3f35-11e9-89ca-f30f0ca38f46.png)


