### PR TITLE
Appveyor add again lint-styles

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,4 @@ build_script:
   - npm run build
 test_script:
   - npm run lint
+  - npm run lint-styles


### PR DESCRIPTION
`lint-styles` was removed from Appveyor in https://github.com/maputnik/editor/pull/280/commits/1805aee7ba559327b6aa068d7662120f62d65c62 but it seems to work now.