### PR TITLE
Change Maptiler URLs

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -50,9 +50,10 @@ function normalizeSourceURL (url, apiToken="") {
 }
 
 function setFetchAccessToken(url, mapStyle) {
+  const matchesTilehosting = url.match(/\.tilehosting\.com/);
   const matchesMaptiler = url.match(/\.maptiler\.com/);
   const matchesThunderforest = url.match(/\.thunderforest\.com/);
-  if (matchesMaptiler) {
+  if (matchesTilehosting || matchesMaptiler) {
     const accessToken = style.getAccessToken("openmaptiles", mapStyle, {allowFallback: true})
     if (accessToken) {
       return url.replace('{key}', accessToken)

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -50,9 +50,9 @@ function normalizeSourceURL (url, apiToken="") {
 }
 
 function setFetchAccessToken(url, mapStyle) {
-  const matchesTilehosting = url.match(/\.tilehosting\.com/);
+  const matchesMaptiler = url.match(/\.maptiler\.com/);
   const matchesThunderforest = url.match(/\.thunderforest\.com/);
-  if (matchesTilehosting) {
+  if (matchesMaptiler) {
     const accessToken = style.getAccessToken("openmaptiles", mapStyle, {allowFallback: true})
     if (accessToken) {
       return url.replace('{key}', accessToken)

--- a/src/config/tilesets.json
+++ b/src/config/tilesets.json
@@ -1,7 +1,7 @@
 {
   "openmaptiles": {
     "type": "vector",
-    "url": "https://maps.tilehosting.com/data/v3.json?key={key}",
+    "url": "https://api.maptiler.com/tiles/v3/tiles.json?key={key}",
     "title": "OpenMapTiles"
   },
   "thunderforest_transport": {

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -101,7 +101,7 @@ function replaceAccessTokens(mapStyle, opts={}) {
     changedStyle = replaceSourceAccessToken(changedStyle, sourceName, opts);
   })
 
-  if (mapStyle.glyphs && mapStyle.glyphs.match(/\.maptiler\.com/)) {
+  if (mapStyle.glyphs && (mapStyle.glyphs.match(/\.tilehosting\.com/) || mapStyle.glyphs.match(/\.maptiler\.com/))) {
     const newAccessToken = getAccessToken("openmaptiles", mapStyle, opts);
     if (newAccessToken) {
       changedStyle = {

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -101,7 +101,7 @@ function replaceAccessTokens(mapStyle, opts={}) {
     changedStyle = replaceSourceAccessToken(changedStyle, sourceName, opts);
   })
 
-  if (mapStyle.glyphs && mapStyle.glyphs.match(/\.tilehosting\.com/)) {
+  if (mapStyle.glyphs && mapStyle.glyphs.match(/\.maptiler\.com/)) {
     const newAccessToken = getAccessToken("openmaptiles", mapStyle, opts);
     if (newAccessToken) {
       changedStyle = {


### PR DESCRIPTION
This change is because of the MapTiler Cloud infrastructure upgrade:

https://www.maptiler.com/blog/2019/04/maptiler-cloud-infrastructure-upgrade.html

This PR should be merged after the OMT styles are reflecting this change.