### PR TITLE
Prevent native browser undo/redo when handled by app

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -217,20 +217,24 @@ export default class App extends React.Component {
     })
   }
 
-  handleKeyPress(e) {
+  handleKeyPress = (e) => {
     if(navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
       if(e.metaKey && e.shiftKey && e.keyCode === 90) {
+        e.preventDefault();
         this.onRedo(e);
       }
       else if(e.metaKey && e.keyCode === 90) {
+        e.preventDefault();
         this.onUndo(e);
       }
     }
     else {
       if(e.ctrlKey && e.keyCode === 90) {
+        e.preventDefault();
         this.onUndo(e);
       }
       else if(e.ctrlKey && e.keyCode === 89) {
+        e.preventDefault();
         this.onRedo(e);
       }
     }


### PR DESCRIPTION
Sometimes when editing a inputs `ctrl+z` was causing an app undo event and a native browser undo event at the same time. This prevents the browser from handling the undo event.