### PR TITLE
Added semi-hidden debug modal

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -213,7 +213,7 @@ export default class App extends React.Component {
         survey: localStorage.hasOwnProperty('survey') ? false : true,
         debug: false,
       },
-      mapOptions: {
+      mapboxGlDebugOptions: {
         showTileBoundaries: false,
         showCollisionBoxes: false,
         showOverdrawInspector: false,
@@ -469,18 +469,22 @@ export default class App extends React.Component {
     }
   }
 
+  _getRenderer () {
+    const metadata = this.state.mapStyle.metadata || {};
+    return metadata['maputnik:renderer'] || 'mbgljs';
+  }
+
   mapRenderer() {
     const mapProps = {
       mapStyle: style.replaceAccessTokens(this.state.mapStyle, {allowFallback: true}),
-      options: this.state.mapOptions,
+      options: this.state.mapboxGlDebugOptions,
       onDataChange: (e) => {
         this.layerWatcher.analyzeMap(e.map)
         this.fetchSources();
       },
     }
 
-    const metadata = this.state.mapStyle.metadata || {}
-    const renderer = metadata['maputnik:renderer'] || 'mbgljs'
+    const renderer = this._getRenderer();
 
     let mapElement;
 
@@ -532,10 +536,10 @@ export default class App extends React.Component {
     this.setModal(modalName, !this.state.isOpen[modalName]);
   }
 
-  onChangeDebug = (key, value) => {
+  onChangeMaboxGlDebug = (key, value) => {
     this.setState({
-      mapOptions: {
-        ...this.state.mapOptions,
+      mapboxGlDebugOptions: {
+        ...this.state.mapboxGlDebugOptions,
         [key]: value, 
       }
     });
@@ -593,8 +597,9 @@ export default class App extends React.Component {
 
     const modals = <div>
       <DebugModal
-        debugOptions={this.state.mapOptions}
-        onChangeDebug={this.onChangeDebug}
+        renderer={this._getRenderer()}
+        mapboxGlDebugOptions={this.state.mapboxGlDebugOptions}
+        onChangeMaboxGlDebug={this.onChangeMaboxGlDebug}
         isOpen={this.state.isOpen.debug}
         onOpenToggle={this.toggleModal.bind(this, 'debug')}
       />

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -19,6 +19,7 @@ import SourcesModal from './modals/SourcesModal'
 import OpenModal from './modals/OpenModal'
 import ShortcutsModal from './modals/ShortcutsModal'
 import SurveyModal from './modals/SurveyModal'
+import DebugModal from './modals/DebugModal'
 
 import { downloadGlyphsMetadata, downloadSpriteMetadata } from '../libs/metadata'
 import {latest, validate} from '@mapbox/mapbox-gl-style-spec'
@@ -139,6 +140,12 @@ export default class App extends React.Component {
           document.querySelector(".mapboxgl-canvas").focus();
         }
       },
+      {
+        key: "!",
+        handler: () => {
+          this.toggleModal("debug");
+        }
+      },
     ]
 
     document.body.addEventListener("keyup", (e) => {
@@ -203,12 +210,13 @@ export default class App extends React.Component {
         open: false,
         shortcuts: false,
         export: false,
-        survey: localStorage.hasOwnProperty('survey') ? false : true
+        survey: localStorage.hasOwnProperty('survey') ? false : true,
+        debug: false,
       },
       mapOptions: {
-        showTileBoundaries: queryUtil.asBool(queryObj, "show-tile-boundaries"),
-        showCollisionBoxes: queryUtil.asBool(queryObj, "show-collision-boxes"),
-        showOverdrawInspector: queryUtil.asBool(queryObj, "show-overdraw-inspector")
+        showTileBoundaries: false,
+        showCollisionBoxes: false,
+        showOverdrawInspector: false,
       },
     }
 
@@ -524,6 +532,15 @@ export default class App extends React.Component {
     this.setModal(modalName, !this.state.isOpen[modalName]);
   }
 
+  onChangeDebug = (key, value) => {
+    this.setState({
+      mapOptions: {
+        ...this.state.mapOptions,
+        [key]: value, 
+      }
+    });
+  }
+
   render() {
     const layers = this.state.mapStyle.layers || []
     const selectedLayer = layers.length > 0 ? layers[this.state.selectedLayerIndex] : null
@@ -575,6 +592,12 @@ export default class App extends React.Component {
 
 
     const modals = <div>
+      <DebugModal
+        debugOptions={this.state.mapOptions}
+        onChangeDebug={this.onChangeDebug}
+        isOpen={this.state.isOpen.debug}
+        onOpenToggle={this.toggleModal.bind(this, 'debug')}
+      />
       <ShortcutsModal
         ref={(el) => this.shortcutEl = el}
         isOpen={this.state.isOpen.shortcuts}

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Modal from './Modal'
+
+
+class DebugModal extends React.Component {
+  static propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onOpenToggle: PropTypes.func.isRequired,
+    debugOptions: PropTypes.object,
+  }
+
+  render() {
+    return <Modal
+      data-wd-key="debug-modal"
+      isOpen={this.props.isOpen}
+      onOpenToggle={this.props.onOpenToggle}
+      title={'Debug'}
+    >
+      <div className="maputnik-modal-section maputnik-modal-shortcuts">
+        <ul>
+          {Object.entries(this.props.debugOptions).map(([key, val]) => {
+            return <li key={key}>
+              <label>
+                <input type="checkbox" value={val} onClick={(e) => this.props.onChangeDebug(key, e.target.checked)} /> {key}
+              </label>
+            </li>
+          })}
+        </ul>
+      </div>
+    </Modal>
+  }
+}
+
+export default DebugModal;

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -7,7 +7,7 @@ import Modal from './Modal'
 class DebugModal extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
-    onOpenToggle: PropTypes.func.isRequired,
+    onChangeDebug: PropTypes.func.isRequired,
     debugOptions: PropTypes.object,
   }
 

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -7,9 +7,10 @@ import Modal from './Modal'
 class DebugModal extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
-    onChangeDebug: PropTypes.func.isRequired,
+    renderer: PropTypes.string.isRequired,
+    onChangeMaboxGlDebug: PropTypes.func.isRequired,
     onOpenToggle: PropTypes.func.isRequired,
-    debugOptions: PropTypes.object,
+    mapboxGlDebugOptions: PropTypes.object,
   }
 
   render() {
@@ -20,15 +21,22 @@ class DebugModal extends React.Component {
       title={'Debug'}
     >
       <div className="maputnik-modal-section maputnik-modal-shortcuts">
-        <ul>
-          {Object.entries(this.props.debugOptions).map(([key, val]) => {
-            return <li key={key}>
-              <label>
-                <input type="checkbox" value={val} onClick={(e) => this.props.onChangeDebug(key, e.target.checked)} /> {key}
-              </label>
-            </li>
-          })}
-        </ul>
+        {this.props.renderer === 'mbgljs' &&
+          <ul>
+            {Object.entries(this.props.mapboxGlDebugOptions).map(([key, val]) => {
+              return <li key={key}>
+                <label>
+                  <input type="checkbox" checked={val} onClick={(e) => this.props.onChangeMaboxGlDebug(key, e.target.checked)} /> {key}
+                </label>
+              </li>
+            })}
+          </ul>
+        }
+        {this.props.renderer === 'ol' &&
+          <div>
+            No debug options available for the OpenLayers renderer
+          </div>
+        }
       </div>
     </Modal>
   }

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -8,6 +8,7 @@ class DebugModal extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onChangeDebug: PropTypes.func.isRequired,
+    onOpenToggle: PropTypes.func.isRequired,
     debugOptions: PropTypes.object,
   }
 

--- a/src/components/modals/ShortcutsModal.jsx
+++ b/src/components/modals/ShortcutsModal.jsx
@@ -40,6 +40,10 @@ class ShortcutsModal extends React.Component {
         key: "m",
         text: "Focus map"
       },
+      {
+        key: "!",
+        text: "Debug modal"
+      },
     ]
 
 


### PR DESCRIPTION
A PR for #460

@pathmapper to not add clutter to the toolbar, how about a hidden modal. Just press `!` for the debug modal (`?` to see the shortcuts)

Then you'll get a modal pop up with some debug options.

<img width="399" alt="Screen Shot 2019-05-18 at 19 10 53" src="https://user-images.githubusercontent.com/235915/57973427-bd598680-79a0-11e9-9aaa-21a9e63d4389.png">


I figured because we don't display that these options are enabled in the UI anywhere at the moment, a novice user could accidentally enable these options. For this reason they will reset on browser refresh (we can change that later down the road)

I've also removed the url param method of enabling these feature as a part of this PR

Does that meet your requirements?

Demo: <https://1280-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html#0.34/0/0>

Fixes #460 (...if @pathmapper likes it 😄 ) 
