### PR TITLE
Further OpenLayers improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8356,6 +8356,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "maputnik-design": "github:maputnik/design",
     "ol": "^6.0.0-beta.8",
     "ol-mapbox-style": "^5.0.0-beta.2",
+    "proj4": "^2.5.0",
     "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-aria-menubutton": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "maputnik-design": "github:maputnik/design",
     "ol": "^6.0.0-beta.8",
     "ol-mapbox-style": "^5.0.0-beta.2",
-    "proj4": "^2.5.0",
     "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-aria-menubutton": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash.capitalize": "^4.2.1",
     "lodash.clamp": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^0.53.1",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,6 +2,7 @@ import autoBind from 'react-autobind';
 import React from 'react'
 import cloneDeep from 'lodash.clonedeep'
 import clamp from 'lodash.clamp'
+import get from 'lodash.get'
 import {arrayMove} from 'react-sortable-hoc'
 import url from 'url'
 
@@ -277,6 +278,27 @@ export default class App extends React.Component {
     downloadSpriteMetadata(baseUrl, icons => {
       this.setState({ spec: updateRootSpec(this.state.spec, 'sprite', icons)})
     })
+  }
+
+  onChangeMetadataProperty = (property, value) => {
+    // If we're changing renderer reset the map state.
+    if (
+      property === 'maputnik:renderer' &&
+      value !== get(this.state.mapStyle, ['metadata', 'maputnik:renderer'], 'mbgljs')
+    ) {
+      this.setState({
+        mapState: 'map'
+      });
+    }
+
+    const changedStyle = {
+      ...this.state.mapStyle,
+      metadata: {
+        ...this.state.mapStyle.metadata,
+        [property]: value
+      }
+    }
+    this.onStyleChanged(changedStyle)
   }
 
   onStyleChanged = (newStyle, save=true) => {
@@ -634,6 +656,7 @@ export default class App extends React.Component {
       <SettingsModal
         mapStyle={this.state.mapStyle}
         onStyleChanged={this.onStyleChanged}
+        onChangeMetadataProperty={this.onChangeMetadataProperty}
         isOpen={this.state.isOpen.settings}
         onOpenToggle={this.toggleModal.bind(this, 'settings')}
         openlayersDebugOptions={this.state.openlayersDebugOptions}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -219,7 +219,7 @@ export default class App extends React.Component {
         showOverdrawInspector: false,
       },
       openlayersDebugOptions: {
-        debugToolbox: true,
+        debugToolbox: false,
       },
     }
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -483,11 +483,6 @@ export default class App extends React.Component {
     return metadata['maputnik:renderer'] || 'mbgljs';
   }
 
-  getProjectionCode () {
-    const metadata = this.state.mapStyle.metadata || {};
-    return this.state.openlayersDebugOptions.enableProjections ? metadata['maputnik:projection'] : "EPSG:3857";
-  }
-
   mapRenderer() {
     const metadata = this.state.mapStyle.metadata || {};
 
@@ -507,7 +502,6 @@ export default class App extends React.Component {
     if(renderer === 'ol') {
       mapElement = <OpenLayersMap
         {...mapProps}
-        projectionCode={this.getProjectionCode()}
         debugToolbox={this.state.openlayersDebugOptions.debugToolbox}
         onLayerSelect={this.onLayerSelect}
       />

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -219,8 +219,6 @@ export default class App extends React.Component {
         showOverdrawInspector: false,
       },
       openlayersDebugOptions: {
-        // TODO: For future projection work
-        // enableProjections: true,
         debugToolbox: true,
       },
     }

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -139,6 +139,7 @@ export default class Toolbar extends React.Component {
       {
         id: "inspect",
         title: "Inspect",
+        disabled: this.props.renderer !== 'mbgljs',
       },
       {
         id: "filter-deuteranopia",

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -114,6 +114,7 @@ export default class Toolbar extends React.Component {
     onToggleModal: PropTypes.func,
     onSetMapState: PropTypes.func,
     mapState: PropTypes.string,
+    renderer: PropTypes.string,
   }
 
   state = {

--- a/src/components/map/FeatureLayerPopup.jsx
+++ b/src/components/map/FeatureLayerPopup.jsx
@@ -34,6 +34,11 @@ class FeatureLayerPopup extends React.Component {
   }
 
   _getFeatureColor(feature, zoom) {
+    // Guard because openlayers won't have this
+    if (!feature.layer.paint) {
+      return;
+    }
+
     try {
       const paintProps = feature.layer.paint;
       let propName;
@@ -105,11 +110,13 @@ class FeatureLayerPopup extends React.Component {
               this.props.onLayerSelect(feature.layer.id)
             }}
           >
-            <LayerIcon type={feature.layer.type} style={{
-              width: 14,
-              height: 14,
-              paddingRight: 3
-            }}/>
+            {feature.layer.type && 
+              <LayerIcon type={feature.layer.type} style={{
+                width: 14,
+                height: 14,
+                paddingRight: 3
+              }}/>
+            }
             {feature.layer.id}
             {feature.counter && <span> × {feature.counter}</span>}
           </label>

--- a/src/components/map/OpenLayersMap.jsx
+++ b/src/components/map/OpenLayersMap.jsx
@@ -9,14 +9,8 @@ import 'ol/ol.css'
 import {apply} from 'ol-mapbox-style';
 import {Map, View, Proj, Overlay} from 'ol';
 
-import proj4 from 'proj4';
-import {register} from 'ol/proj/proj4';
-import {get as getProjection, toLonLat} from 'ol/proj';
+import {toLonLat} from 'ol/proj';
 import {toStringHDMS} from 'ol/coordinate';
-
-// Register some projections...
-proj4.defs('EPSG:3031', '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ');
-register(proj4);
 
 
 function renderCoords (coords) {
@@ -64,21 +58,7 @@ export default class OpenLayersMap extends React.Component {
     apply(this.map, newMapStyle);
   }
 
-  updateProjection () {
-    this.projection = getProjection(this.props.projectionCode || "EPSG:3857");
-  }
-
   componentDidUpdate(prevProps) {
-    if (this.props.projectionCode !== prevProps.projectionCode) {
-      this.updateProjection();
-      this.map.setView(
-        new View({
-          projection: this.projection,
-          zoom: 1,
-          center: [180, -90]
-        })
-      );
-    }
     if (this.props.mapStyle !== prevProps.mapStyle) {
       this.updateStyle(this.props.mapStyle);
     }
@@ -93,20 +73,17 @@ export default class OpenLayersMap extends React.Component {
       }
     });
 
-    this.updateProjection();
-
     const map = new Map({
       target: this.container,
       overlays: [this.overlay],
       view: new View({
-        projection: this.projection,
         zoom: 1,
         center: [180, -90],
       })
     });
 
     map.on('pointermove', (evt) => {
-      var coords = toLonLat(evt.coordinate, this.projection);
+      var coords = toLonLat(evt.coordinate);
       this.setState({
         cursor: [
           coords[0].toFixed(2),
@@ -116,7 +93,7 @@ export default class OpenLayersMap extends React.Component {
     })
 
     map.on('postrender', (evt) => {
-      const center = toLonLat(map.getView().getCenter(), this.projection);
+      const center = toLonLat(map.getView().getCenter());
       this.setState({
         center: [
           center[0].toFixed(2),

--- a/src/components/map/OpenLayersMap.jsx
+++ b/src/components/map/OpenLayersMap.jsx
@@ -31,6 +31,7 @@ export default class OpenLayersMap extends React.Component {
     accessToken: PropTypes.string,
     style: PropTypes.object,
     onLayerSelect: PropTypes.func.isRequired,
+    debugToolbox: PropTypes.bool.isRequired,
   }
 
   static defaultProps = {
@@ -123,7 +124,7 @@ export default class OpenLayersMap extends React.Component {
         className="maputnik-popup"
       >
         <button
-          class="mapboxgl-popup-close-button"
+          className="mapboxgl-popup-close-button"
           onClick={this.closeOverlay}
           aria-label="Close popup"
         >

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -9,6 +9,7 @@ class DebugModal extends React.Component {
     isOpen: PropTypes.bool.isRequired,
     renderer: PropTypes.string.isRequired,
     onChangeMaboxGlDebug: PropTypes.func.isRequired,
+    onChangeOpenlayersDebug: PropTypes.func.isRequired,
     onOpenToggle: PropTypes.func.isRequired,
     mapboxGlDebugOptions: PropTypes.object,
     openlayersDebugOptions: PropTypes.object,

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -11,6 +11,7 @@ class DebugModal extends React.Component {
     onChangeMaboxGlDebug: PropTypes.func.isRequired,
     onOpenToggle: PropTypes.func.isRequired,
     mapboxGlDebugOptions: PropTypes.object,
+    openlayersDebugOptions: PropTypes.object,
   }
 
   render() {
@@ -33,9 +34,15 @@ class DebugModal extends React.Component {
           </ul>
         }
         {this.props.renderer === 'ol' &&
-          <div>
-            No debug options available for the OpenLayers renderer
-          </div>
+          <ul>
+            {Object.entries(this.props.openlayersDebugOptions).map(([key, val]) => {
+              return <li key={key}>
+                <label>
+                  <input type="checkbox" checked={val} onClick={(e) => this.props.onChangeOpenlayersDebug(key, e.target.checked)} /> {key}
+                </label>
+              </li>
+            })}
+          </ul>
         }
       </div>
     </Modal>

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -109,6 +109,21 @@ class SettingsModal extends React.Component {
           onChange={this.changeMetadataProperty.bind(this, 'maputnik:renderer')}
         />
       </InputBlock>
+
+      {this.props.openlayersDebugOptions.enableProjections &&
+        <InputBlock label={"Projection (experimental)"} doc={"Projection of the data"}>
+          <SelectInput {...inputProps}
+            data-wd-key="modal-settings.maputnik:projection" 
+            options={[
+              ['EPSG:3857', '[EPSG:3857] Web Mercator'],
+              ['EPSG:3031', '[EPSG:3031] Antarctic Polar Stereographic (experimental)'],
+            ]}
+            value={metadata['maputnik:projection'] || 'EPSG:3857'}
+            onChange={this.changeMetadataProperty.bind(this, 'maputnik:projection')}
+          />
+        </InputBlock>
+      }
+
       </div>
     </Modal>
   }

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -11,6 +11,7 @@ class SettingsModal extends React.Component {
   static propTypes = {
     mapStyle: PropTypes.object.isRequired,
     onStyleChanged: PropTypes.func.isRequired,
+    onChangeMetadataProperty: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,
     onOpenToggle: PropTypes.func.isRequired,
   }
@@ -23,19 +24,9 @@ class SettingsModal extends React.Component {
     this.props.onStyleChanged(changedStyle)
   }
 
-  changeMetadataProperty(property, value) {
-    const changedStyle = {
-      ...this.props.mapStyle,
-      metadata: {
-        ...this.props.mapStyle.metadata,
-        [property]: value
-      }
-    }
-    this.props.onStyleChanged(changedStyle)
-  }
-
   render() {
     const metadata = this.props.mapStyle.metadata || {}
+    const {onChangeMetadataProperty} = this.props;
     const inputProps = { }
     return <Modal
       data-wd-key="modal-settings"
@@ -78,7 +69,7 @@ class SettingsModal extends React.Component {
         <StringInput {...inputProps}
           data-wd-key="modal-settings.maputnik:mapbox_access_token" 
           value={metadata['maputnik:mapbox_access_token']}
-          onChange={this.changeMetadataProperty.bind(this, "maputnik:mapbox_access_token")}
+          onChange={onChangeMetadataProperty.bind(this, "maputnik:mapbox_access_token")}
         />
       </InputBlock>
 
@@ -86,7 +77,7 @@ class SettingsModal extends React.Component {
         <StringInput {...inputProps}
           data-wd-key="modal-settings.maputnik:openmaptiles_access_token" 
           value={metadata['maputnik:openmaptiles_access_token']}
-          onChange={this.changeMetadataProperty.bind(this, "maputnik:openmaptiles_access_token")}
+          onChange={onChangeMetadataProperty.bind(this, "maputnik:openmaptiles_access_token")}
         />
       </InputBlock>
 
@@ -94,7 +85,7 @@ class SettingsModal extends React.Component {
         <StringInput {...inputProps}
           data-wd-key="modal-settings.maputnik:thunderforest_access_token" 
           value={metadata['maputnik:thunderforest_access_token']}
-          onChange={this.changeMetadataProperty.bind(this, "maputnik:thunderforest_access_token")}
+          onChange={onChangeMetadataProperty.bind(this, "maputnik:thunderforest_access_token")}
         />
       </InputBlock>
 
@@ -106,7 +97,7 @@ class SettingsModal extends React.Component {
             ['ol', 'Open Layers (experimental)'],
           ]}
           value={metadata['maputnik:renderer'] || 'mbgljs'}
-          onChange={this.changeMetadataProperty.bind(this, 'maputnik:renderer')}
+          onChange={onChangeMetadataProperty.bind(this, 'maputnik:renderer')}
         />
       </InputBlock>
 

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -110,20 +110,6 @@ class SettingsModal extends React.Component {
         />
       </InputBlock>
 
-      {this.props.openlayersDebugOptions.enableProjections &&
-        <InputBlock label={"Projection (experimental)"} doc={"Projection of the data"}>
-          <SelectInput {...inputProps}
-            data-wd-key="modal-settings.maputnik:projection" 
-            options={[
-              ['EPSG:3857', '[EPSG:3857] Web Mercator'],
-              ['EPSG:3031', '[EPSG:3031] Antarctic Polar Stereographic (experimental)'],
-            ]}
-            value={metadata['maputnik:projection'] || 'EPSG:3857'}
-            onChange={this.changeMetadataProperty.bind(this, 'maputnik:projection')}
-          />
-        </InputBlock>
-      }
-
       </div>
     </Modal>
   }

--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -1,7 +1,13 @@
 //OPENLAYERS
 .maputnik-layout {
   .ol-zoom {
-    top: 10px;
+    top: 40px;
+    right: 10px;
+    left: auto;
+  }
+
+  .ol-rotate {
+    top: 94px;
     right: 10px;
     left: auto;
   }
@@ -19,4 +25,58 @@
       background-color: rgb(86, 83, 83);
     }
   }
+}
+
+
+.maputnik-ol {
+  width: 100%;
+  height: 100%;
+}
+
+.maputnik-ol-popup {
+  background: $color-black;
+
+}
+
+.maputnik-coords {
+  font-family: monospace;
+  &:before {
+    content: '[';
+    color: #888;
+  }
+  &:after {
+    content: ']';
+    color: #888;
+  }
+}
+
+.maputnik-ol-debug {
+  font-family: monospace;
+  font-size: smaller;
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: rgb(28, 31, 36);
+  padding: 6px 8px;
+  border-radius: 2px;
+  z-indeX: 9999;
+}
+
+.maputnik-ol-zoom {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  background: #1c1f24;
+  border-radius: 2px;
+  padding: 6px 8px;
+  color: $color-lowgray;
+  z-indeX: 9999;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.maputnik-ol-container {
+  display: flex;
+  flex: 1;
+  position: relative;
 }

--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -59,7 +59,7 @@
   background: rgb(28, 31, 36);
   padding: 6px 8px;
   border-radius: 2px;
-  z-indeX: 9999;
+  z-index: 9999;
 }
 
 .maputnik-ol-zoom {
@@ -70,7 +70,7 @@
   border-radius: 2px;
   padding: 6px 8px;
   color: $color-lowgray;
-  z-indeX: 9999;
+  z-index: 9999;
   font-size: 12px;
   font-weight: bold;
 }

--- a/src/styles/_popup.scss
+++ b/src/styles/_popup.scss
@@ -22,7 +22,7 @@
 
 .maputnik-popup-layer-id {
   padding-left: $margin-2;
-  padding-right: $margin-2;
+  padding-right: 1.6em;
   background-color: $color-midgray;
   color: $color-white;
 }


### PR DESCRIPTION
Over the weekend I was trying to get an antarctic map rendering with `ol-mapbox-style` and some vector tiles that I've projected using `ogr2ogr`. I have a very hacked together version of that 'kinda works' (more on that in later PR's), however along the way I made a couple of improvements to the OL renderer.  

I've added

 - Disable inspect mode for openlayers render as it doesn't work
 - Added debug toolbox to tell me the current state of the openlayers map (mainly for debugging projections, but generally useful), note this is behind a setting in the debug modal
 - Zoom display UI, the same as the mapbox-gl renderer
 - Fixed rendering of rotate UI

Screenshot

<img width="775" alt="Screen Shot 2019-05-29 at 19 24 45" src="https://user-images.githubusercontent.com/235915/58581502-9d02b500-8247-11e9-8be5-6409111a4a9c.png">

Fixes #254 