### PR TITLE
Update Maptiler key

### DIFF
--- a/src/config/tokens.json
+++ b/src/config/tokens.json
@@ -1,5 +1,5 @@
 {
   "mapbox": "pk.eyJ1IjoibW9yZ2Vua2FmZmVlIiwiYSI6ImNpeHJmNXNmZTAwNHIycXBid2NqdTJibjMifQ.Dv1-GDpTWi0NP6xW9Fct1w",
-  "openmaptiles": "Og58UhhtiiTaLVlPtPgs",
+  "openmaptiles": "KDhMfHvorAFkFe64wlZb",
   "thunderforest": "b71f7f0ba4064f5eb9e903859a9cf5c6"
 }


### PR DESCRIPTION
https://www.maptiler.com/cloud/ have kindly given us a new key for the use in the editor.

It replaces the old key which was limited to 100k requests/month and caused https://github.com/maputnik/editor/issues/541 because this limit was exceeded.

Thanks @klokan !