### PR TITLE
Add 1.6.0-beta to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A free and open visual editor for the [Mapbox GL styles](https://www.mapbox.com/
 targeted at developers and map designers.
 
 - :link: Design your maps online at **<https://maputnik.github.io/editor/>** (all in local storage)
+- :link: Try out the v1.6.0-beta release at: https://maputnik.github.io/releases/v1.6.0-beta/
 - :link: Use the [Maputnik CLI](https://github.com/maputnik/editor/wiki/Maputnik-CLI) for local style development
 
 Mapbox has built one of the best and most amazing OSS ecosystems. A key component to ensure its longevity and independence is an OSS map designer.


### PR DESCRIPTION
Besides https://github.com/maputnik/editor/issues/541, some things are not working anymore with `v1.5.0`, e.g. the _Klokantech Basic_ and _OSM Bright_ styles. So this PR adds the `v1.6.0-beta` to the readme.