### PR TITLE
LayerList performance improvements

### DIFF
--- a/config/webpack.production.config.js
+++ b/config/webpack.production.config.js
@@ -18,6 +18,9 @@ module.exports = {
     filename: '[name].[contenthash].js',
     chunkFilename: '[contenthash].js'
   },
+  optimization:{
+    minimize: false,
+  },
   resolve: {
     extensions: ['.js', '.jsx']
   },

--- a/config/webpack.production.config.js
+++ b/config/webpack.production.config.js
@@ -18,9 +18,6 @@ module.exports = {
     filename: '[name].[contenthash].js',
     chunkFilename: '[contenthash].js'
   },
-  optimization:{
-    minimize: false,
-  },
   resolve: {
     extensions: ['.js', '.jsx']
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "detect-browser": "^4.5.0",
     "file-saver": "^1.3.8",
     "jsonlint": "github:josdejong/jsonlint#85a19d7",
+    "lodash": "^4.17.15",
     "lodash.capitalize": "^4.2.1",
     "lodash.clamp": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",

--- a/src/components/fields/ColorField.jsx
+++ b/src/components/fields/ColorField.jsx
@@ -30,7 +30,7 @@ class ColorField extends React.Component {
   }
 
   onChangeNoCheck (v) {
-    this.props.onChange(formatColor(v));
+    this.props.onChange(v);
   }
 
   //TODO: I much rather would do this with absolute positioning

--- a/src/components/fields/ColorField.jsx
+++ b/src/components/fields/ColorField.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Color from 'color'
 import ChromePicker from 'react-color/lib/components/chrome/Chrome'
 import PropTypes from 'prop-types'
+import lodash from 'lodash';
 
 function formatColor(color) {
   const rgb = color.rgb
@@ -21,6 +22,15 @@ class ColorField extends React.Component {
 
   state = {
     pickerOpened: false
+  }
+
+  constructor () {
+    super();
+    this.onChangeNoCheck = lodash.throttle(this.onChangeNoCheck, 1000/30);
+  }
+
+  onChangeNoCheck (v) {
+    this.props.onChange(formatColor(v));
   }
 
   //TODO: I much rather would do this with absolute positioning
@@ -82,7 +92,7 @@ class ColorField extends React.Component {
       }}>
       <ChromePicker
         color={currentColor}
-        onChange={c => this.props.onChange(formatColor(c))}
+        onChange={c => this.onChangeNoCheck(formatColor(c))}
       />
       <div
         className="maputnik-color-picker-offset"


### PR DESCRIPTION
So to follow on from @pathmapper comment in https://github.com/maputnik/editor/pull/521#issuecomment-493949882 it does indeed look like the performance has suffered between `v1.5.0` and `v1.6.0`. Although the 84ms mentioned in https://github.com/maputnik/editor/issues/372 was clearly just incorrect results, see results from v1.5.0 below (no idea what mistake I made perviously)

The condition I'm testing is changing the background color of osm-liberty. The reults from the devtools performance profiler are as follows

v1.5.0

<img width="196" alt="Screen Shot 2019-10-13 at 11 31 26" src="https://user-images.githubusercontent.com/235915/66714299-09bcbd00-edad-11e9-92b9-50a4a265a21d.png">

v1.6.0

<img width="267" alt="Screen Shot 2019-10-13 at 11 30 11" src="https://user-images.githubusercontent.com/235915/66714290-e2fe8680-edac-11e9-9fc9-59c3fc0a6319.png">



If I run it in development it's significantly slower, I'm assuming all the react profiling metrics is causing some of that slow down. But for the following demonstration, lower numbers are better and don't compare them to the production builds above.

So the current v1.6.0 branch run in development is taking around 700-800ms to render a frame once the background color is changed.

<img width="329" alt="Screen Shot 2019-10-13 at 11 12 52" src="https://user-images.githubusercontent.com/235915/66714117-b6496f80-edaa-11e9-8787-df0569492d0a.png">

However if we dive a little deeper in the call trace we can see that the sortable list is causing most of the issues. 

<img width="334" alt="Screen Shot 2019-10-13 at 11 12 59" src="https://user-images.githubusercontent.com/235915/66714120-ba758d00-edaa-11e9-9209-35109357954e.png">

This is wasted CPU cycles because rather than rendering every component to work out what has changed. We can instead just check the layers list for `id` or `layout.visibility` changes, because thats the only thing that's used in sub components of `<LayerList/>`. This PR adds a   `shouldComponentUpdate` function to check for that condition.

With that update applied, I rebuilt a production build of the app with those changes and retested.

Demo: https://1505-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html

<img width="262" alt="Screen Shot 2019-10-13 at 11 33 18" src="https://user-images.githubusercontent.com/235915/66714346-95364e00-edad-11e9-9a76-c24ec6154223.png">

Now we're back down to ~140ms for a frame, which is slightly better than v1.5.0, and significantly better than v1.6.0. 

For anybody outside the Maputnik team reading this, we know that 140ms isn't ideal performance. We do have further improvements in the works, see #521, however those will take a little more time to get right.

I also throttled `<ChromePicker/>` to 30fps, I didn't notice any major improvement with this applied. However it's good practice to throttle updates.

All the testing was completed on the same laptop, within a short time window with no other apps running except chrome, a terminal and the activity monitor.