### PR TITLE
Set a color for the OpenLayers attribution control

### DIFF
--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -16,6 +16,11 @@
     height: 20px;
   }
 
+  .ol-attribution a {
+    color: rgba(0, 0, 0, 0.75);
+    text-decoration: none;
+  }
+
   .ol-control {
     button {
       background-color: rgb(28, 31, 36);


### PR DESCRIPTION
The color is currently white on a white div:
![Screenshot from 2019-10-15 14-35-17](https://user-images.githubusercontent.com/100959/66831917-10883300-ef59-11e9-9e6a-2f65c5c13d74.png)
