### PR TITLE
Added profiling build to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ templates:
 
     - run: mkdir -p /tmp/artifacts/logs
     - run: npm run build
-    - run: npm run profiling-build
     - run: npm run lint
     - run: npm run lint-styles
     - store_artifacts:
@@ -42,6 +41,7 @@ templates:
 
     - run: mkdir -p /tmp/artifacts/logs
     - run: npm run build
+    - run: npm run profiling-build
     - run: npm run lint
     - run: npm run lint-styles
     - run: DOCKER_HOST=localhost npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ templates:
 
     - run: mkdir -p /tmp/artifacts/logs
     - run: npm run build
+    - run: npm run profiling-build
     - run: npm run lint
     - run: npm run lint-styles
     - store_artifacts:

--- a/config/webpack.profiling.config.js
+++ b/config/webpack.profiling.config.js
@@ -1,0 +1,20 @@
+const webpackProdConfig = require('./webpack.production.config');
+const artifacts = require("../test/artifacts");
+
+const OUTPATH = artifacts.pathSync("/profiling");
+
+module.exports = {
+  ...webpackProdConfig,
+  output: {
+    ...webpackProdConfig.output,
+    path: OUTPATH,
+  },
+  resolve: {
+    ...webpackProdConfig.resolve,
+    alias: {
+      ...webpackProdConfig.resolve.alias,
+      'react-dom$': 'react-dom/profiling',
+      'scheduler/tracing': 'scheduler/tracing-profiling',
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "stats": "webpack --config config/webpack.production.config.js --profile --json > stats.json",
     "build": "webpack --config config/webpack.production.config.js --progress --profile --colors",
+    "profiling-build": "webpack --config config/webpack.profiling.config.js --progress --profile --colors",
     "test": "cross-env NODE_ENV=test wdio config/wdio.conf.js",
     "test-watch": "cross-env NODE_ENV=test wdio config/wdio.conf.js --watch",
     "start": "webpack-dev-server --progress --profile --colors --config config/webpack.config.js",


### PR DESCRIPTION
From https://github.com/maputnik/editor/pull/557#issuecomment-542103025

> Yeah that's right, so what I'm thinking is that we'll create 2 artifacts from the CI builds one will be the normal build we use to show in demos currently. The other for performance testing we'll include the react [profiling-in-production](https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977#profiling-in-production)

This PR adds a new build with profiling enabled to the artifacts directory `/profiling` so we can use the react profiler

Demo https://1558-84182601-gh.circle-artifacts.com/0/artifacts/profiling/index.html