### PR TITLE
Add support for raw GeoJSON as source

### DIFF
--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -69,12 +69,19 @@ class JSONEditor extends React.Component {
       scrollbarStyle: "null",
     }
 
-    return <CodeMirror
-      value={this.state.code}
-      onBeforeChange={(editor, data, value) => this.onCodeUpdate(value)}
-      onFocusChange={focused => focused ? true : this.resetValue()}
-      options={codeMirrorOptions}
-    />
+    const style = {};
+    if (this.props.maxHeight) {
+      style.maxHeight = this.props.maxHeight;
+    }
+
+    return <div className="CodeMirror-wrapper" style={style}>
+      <CodeMirror
+        value={this.state.code}
+        onBeforeChange={(editor, data, value) => this.onCodeUpdate(value)}
+        onFocusChange={focused => focused ? true : this.resetValue()}
+        options={codeMirrorOptions}
+      />
+    </div>
   }
 }
 

--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -19,6 +19,7 @@ import '../../vendor/codemirror/addon/lint/json-lint'
 class JSONEditor extends React.Component {
   static propTypes = {
     layer: PropTypes.object.isRequired,
+    maxHeight: PropTypes.number,
     onChange: PropTypes.func,
   }
 

--- a/src/components/modals/SourcesModal.jsx
+++ b/src/components/modals/SourcesModal.jsx
@@ -52,7 +52,14 @@ function editorMode(source) {
     if(source.tiles) return 'tilexyz_vector'
     return 'tilejson_vector'
   }
-  if(source.type === 'geojson') return 'geojson'
+  if(source.type === 'geojson') {
+    if (typeof(source.data) === "string") {
+      return 'geojson_url';
+    }
+    else {
+      return 'geojson_json';
+    }
+  }
   return null
 }
 
@@ -106,9 +113,13 @@ class AddSource extends React.Component {
   defaultSource(mode) {
     const source = (this.state || {}).source || {}
     switch(mode) {
-      case 'geojson': return {
+      case 'geojson_url': return {
         type: 'geojson',
         data: source.data || 'http://localhost:3000/geojson.json'
+      }
+      case 'geojson_json': return {
+        type: 'geojson',
+        data: source.data || {}
       }
       case 'tilejson_vector': return {
         type: 'vector',
@@ -155,7 +166,8 @@ class AddSource extends React.Component {
       <InputBlock label={"Source Type"} doc={latest.source_vector.type.doc}>
         <SelectInput
           options={[
-            ['geojson', 'GeoJSON'],
+            ['geojson_json', 'GeoJSON (JSON)'],
+            ['geojson_url', 'GeoJSON (URL)'],
             ['tilejson_vector', 'Vector (TileJSON URL)'],
             ['tilexyz_vector', 'Vector (XYZ URLs)'],
             ['tilejson_raster', 'Raster (TileJSON URL)'],

--- a/src/components/modals/SourcesModal.jsx
+++ b/src/components/modals/SourcesModal.jsx
@@ -115,11 +115,11 @@ class AddSource extends React.Component {
     switch(mode) {
       case 'geojson_url': return {
         type: 'geojson',
-        data: source.data || 'http://localhost:3000/geojson.json'
+        data: 'http://localhost:3000/geojson.json'
       }
       case 'geojson_json': return {
         type: 'geojson',
-        data: source.data || {}
+        data: {}
       }
       case 'tilejson_vector': return {
         type: 'vector',

--- a/src/components/sources/SourceTypeEditor.jsx
+++ b/src/components/sources/SourceTypeEditor.jsx
@@ -5,6 +5,7 @@ import InputBlock from '../inputs/InputBlock'
 import StringInput from '../inputs/StringInput'
 import NumberInput from '../inputs/NumberInput'
 import SelectInput from '../inputs/SelectInput'
+import JSONEditor from '../layers/JSONEditor'
 
 
 class TileJSONSourceEditor extends React.Component {
@@ -86,20 +87,41 @@ class TileURLSourceEditor extends React.Component {
   }
 }
 
-class GeoJSONSourceEditor extends React.Component {
+class GeoJSONSourceUrlEditor extends React.Component {
   static propTypes = {
     source: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   }
 
   render() {
-    return <InputBlock label={"GeoJSON Data"} doc={latest.source_geojson.data.doc}>
+    return <InputBlock label={"GeoJSON URL"} doc={latest.source_geojson.data.doc}>
       <StringInput
         value={this.props.source.data}
         onChange={data => this.props.onChange({
           ...this.props.source,
           data: data
         })}
+      />
+    </InputBlock>
+  }
+}
+
+class GeoJSONSourceJSONEditor extends React.Component {
+  static propTypes = {
+    source: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+  }
+
+  render() {
+    return <InputBlock label={"GeoJSON"} doc={latest.source_geojson.data.doc}>
+      <JSONEditor
+        layer={this.props.source.data}
+        onChange={data => {
+          this.props.onChange({
+            ...this.props.source,
+            data,
+          })
+        }}
       />
     </InputBlock>
   }
@@ -118,7 +140,8 @@ class SourceTypeEditor extends React.Component {
       onChange: this.props.onChange,
     }
     switch(this.props.mode) {
-      case 'geojson': return <GeoJSONSourceEditor {...commonProps} />
+      case 'geojson_url': return <GeoJSONSourceUrlEditor {...commonProps} />
+      case 'geojson_json': return <GeoJSONSourceJSONEditor {...commonProps} />
       case 'tilejson_vector': return <TileJSONSourceEditor {...commonProps} />
       case 'tilexyz_vector': return <TileURLSourceEditor {...commonProps} />
       case 'tilejson_raster': return <TileJSONSourceEditor {...commonProps} />

--- a/src/components/sources/SourceTypeEditor.jsx
+++ b/src/components/sources/SourceTypeEditor.jsx
@@ -116,6 +116,7 @@ class GeoJSONSourceJSONEditor extends React.Component {
     return <InputBlock label={"GeoJSON"} doc={latest.source_geojson.data.doc}>
       <JSONEditor
         layer={this.props.source.data}
+        maxHeight={200}
         onChange={data => {
           this.props.onChange({
             ...this.props.source,

--- a/src/styles/_codemirror.scss
+++ b/src/styles/_codemirror.scss
@@ -1,0 +1,8 @@
+.CodeMirror-lint-tooltip {
+  z-index: 2000 !important;
+}
+
+.CodeMirror-wrapper {
+  position: relative;
+  overflow: auto;
+}

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -180,10 +180,26 @@
   border-width: 2px;
   border-style: solid;
   padding: $margin-2;
+
+  .maputnik-input-block-label {
+    width: 30%;
+  }
+
+  .maputnik-input-block-content {
+    width: 70%;
+  }
 }
 
 .maputnik-add-source {
   @extend .clearfix;
+
+  .maputnik-input-block-label {
+    width: 30%;
+  }
+
+  .maputnik-input-block-content {
+    width: 70%;
+  }
 }
 
 .maputnik-add-source-button {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -39,7 +39,6 @@ $toolbar-offset: 0;
 @import 'map';
 @import 'codemirror';
 @import 'react-collapse';
-@import 'codemirror';
 
 /**
  * Hacks for webdriverio isVisibleWithinViewport

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -37,6 +37,7 @@ $toolbar-offset: 0;
 @import 'zoomproperty';
 @import 'popup';
 @import 'map';
+@import 'codemirror';
 @import 'react-collapse';
 @import 'react-codemirror';
 


### PR DESCRIPTION
Added support for raw GeoJSON to the editor along with sizing edit to make the 'input block labels' take up only 30% of the space in the DataSources modal. 

Screenshot

<img width="363" alt="Screen Shot 2019-10-19 at 13 14 26" src="https://user-images.githubusercontent.com/235915/67144781-91557080-f272-11e9-8fb6-0c623a7bf873.png">

Demo: https://1604-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html

Fixes #559