### PR TITLE
Activate sponsor button in GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: "https://maputnik.github.io/donate"


### PR DESCRIPTION
Displays the "❤️ Sponsor" in the repository, more info:
https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository

The link is the same as the one in the README