### PR TITLE
Simplify and fix vertical alignment of the delete button

### DIFF
--- a/src/styles/_zoomproperty.scss
+++ b/src/styles/_zoomproperty.scss
@@ -45,17 +45,12 @@
 }
 
 .maputnik-delete-stop {
+  display: inline-block;
+  padding-bottom: 0;
+  padding-top: 0;
+  vertical-align: middle;
+
   @extend .maputnik-icon-button;
-
-  vertical-align: top;
-
-  .maputnik-doc-wrapper {
-    width: auto;
-  }
-
-  .maputnik-doc-target {
-    cursor: pointer;
-  }
 }
 
 .maputnik-add-stop {


### PR DESCRIPTION
The delete icon is aligned with the bottom but it should be with the middle.

Use the same css as the `maputnik-make-data-function` and `maputnik-make-zoom-function` buttons.

Before:
![Screenshot from 2019-10-25 13-23-59](https://user-images.githubusercontent.com/100959/67567739-be020000-f72a-11e9-8a6e-bbe4cbdbc230.png)

After:
![Screenshot from 2019-10-25 13-24-35](https://user-images.githubusercontent.com/100959/67567778-d114d000-f72a-11e9-9a9c-4ac146f4ea21.png)

