### PR TITLE
Add open modal and source http/https errors

### DIFF
--- a/src/components/inputs/StringInput.jsx
+++ b/src/components/inputs/StringInput.jsx
@@ -8,8 +8,13 @@ class StringInput extends React.Component {
     style: PropTypes.object,
     default: PropTypes.string,
     onChange: PropTypes.func,
+    onInput: PropTypes.func,
     multi: PropTypes.bool,
     required: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    onInput: () => {},
   }
 
   constructor(props) {
@@ -57,7 +62,9 @@ class StringInput extends React.Component {
         this.setState({
           editing: true,
           value: e.target.value
-        })
+        }, () => {
+          this.props.onInput(this.state.value);
+        });
       },
       onBlur: () => {
         if(this.state.value!==this.props.value) {

--- a/src/components/inputs/UrlInput.jsx
+++ b/src/components/inputs/UrlInput.jsx
@@ -42,6 +42,10 @@ class UrlInput extends React.Component {
     required: PropTypes.bool,
   }
 
+  static defaultProps = {
+    onInput: () => {},
+  }
+
   constructor (props) {
     super(props);
     this.state = {
@@ -53,6 +57,7 @@ class UrlInput extends React.Component {
     this.setState({
       error: validate(url)
     });
+    this.props.onInput(url);
   }
 
   render () {

--- a/src/components/inputs/UrlInput.jsx
+++ b/src/components/inputs/UrlInput.jsx
@@ -3,6 +3,34 @@ import PropTypes from 'prop-types'
 import StringInput from './StringInput'
 import SmallError from '../util/SmallError'
 
+
+function validate (url) {
+  let error;
+  const getProtocol = (url) => {
+    try {
+      const urlObj = new URL(url);
+      return urlObj.protocol;
+    }
+    catch (err) {
+      return undefined;
+    }
+  };
+  const protocol = getProtocol(url);
+  if (
+    protocol &&
+    protocol === "http:" &&
+    window.location.protocol === "https:"
+  ) {
+    error = (
+      <SmallError>
+        CORs policy won&apos;t allow fetching resources served over http from https, use a <code>https://</code> domain
+      </SmallError>
+    );
+  }
+
+  return error;
+}
+
 class UrlInput extends React.Component {
   static propTypes = {
     "data-wd-key": PropTypes.string,
@@ -14,35 +42,17 @@ class UrlInput extends React.Component {
     required: PropTypes.bool,
   }
 
-  state = {
-    error: null,
+  constructor (props) {
+    super(props);
+    this.state = {
+      error: validate(props.value)
+    };
   }
 
   onInput = (url) => {
-    let error;
-    const getProtocol = (url) => {
-      try {
-        const urlObj = new URL(url);
-        return urlObj.protocol;
-      }
-      catch (err) {
-        return undefined;
-      }
-    };
-    const protocol = getProtocol(url);
-    if (
-      protocol &&
-      protocol === "http:" &&
-      window.location.protocol === "https:"
-    ) {
-      error = (
-        <SmallError>
-        CORs policy won&apos;t allow fetching resources served over http from https, use a <code>https://</code> domain
-        </SmallError>
-      );
-    }
-
-    this.setState({error});
+    this.setState({
+      error: validate(url)
+    });
   }
 
   render () {

--- a/src/components/inputs/UrlInput.jsx
+++ b/src/components/inputs/UrlInput.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import StringInput from './StringInput'
+import SmallError from '../util/SmallError'
+
+class UrlInput extends React.Component {
+  static propTypes = {
+    "data-wd-key": PropTypes.string,
+    value: PropTypes.string,
+    style: PropTypes.object,
+    default: PropTypes.string,
+    onChange: PropTypes.func,
+    multi: PropTypes.bool,
+    required: PropTypes.bool,
+  }
+
+  state = {
+    error: null,
+  }
+
+  onInput = (url) => {
+    let error;
+    const getProtocol = (url) => {
+      try {
+        const urlObj = new URL(url);
+        return urlObj.protocol;
+      }
+      catch (err) {
+        return undefined;
+      }
+    };
+    const protocol = getProtocol(url);
+    if (
+      protocol &&
+      protocol === "https:" &&
+      window.location.protocol !== "http:"
+    ) {
+      error = (
+        <SmallError>
+        CORs policy won't allow fetching resources served over http from https, use a <code>https://</code> domain
+        </SmallError>
+      );
+    }
+
+    this.setState({error});
+  }
+
+  render () {
+    return (
+      <div>
+        <StringInput
+          {...this.props}
+          onInput={this.onInput}
+        />
+        {this.state.error}
+      </div>
+    );
+  }
+}
+
+export default UrlInput

--- a/src/components/inputs/UrlInput.jsx
+++ b/src/components/inputs/UrlInput.jsx
@@ -23,7 +23,7 @@ function validate (url) {
   ) {
     error = (
       <SmallError>
-        CORs policy won&apos;t allow fetching resources served over http from https, use a <code>https://</code> domain
+        CORS policy won&apos;t allow fetching resources served over http from https, use a <code>https://</code> domain
       </SmallError>
     );
   }

--- a/src/components/inputs/UrlInput.jsx
+++ b/src/components/inputs/UrlInput.jsx
@@ -32,12 +32,12 @@ class UrlInput extends React.Component {
     const protocol = getProtocol(url);
     if (
       protocol &&
-      protocol === "https:" &&
-      window.location.protocol !== "http:"
+      protocol === "http:" &&
+      window.location.protocol === "https:"
     ) {
       error = (
         <SmallError>
-        CORs policy won't allow fetching resources served over http from https, use a <code>https://</code> domain
+        CORs policy won&apos;t allow fetching resources served over http from https, use a <code>https://</code> domain
         </SmallError>
       );
     }

--- a/src/components/inputs/UrlInput.jsx
+++ b/src/components/inputs/UrlInput.jsx
@@ -38,6 +38,7 @@ class UrlInput extends React.Component {
     style: PropTypes.object,
     default: PropTypes.string,
     onChange: PropTypes.func,
+    onInput: PropTypes.func,
     multi: PropTypes.bool,
     required: PropTypes.bool,
   }

--- a/src/components/map/MapboxGlMap.jsx
+++ b/src/components/map/MapboxGlMap.jsx
@@ -180,6 +180,10 @@ export default class MapboxGlMap extends React.Component {
       })
     })
 
+    map.on("error", e => {
+      console.log("ERROR", e);
+    })
+
     map.on("zoom", e => {
       this.setState({
         zoom: map.getZoom()

--- a/src/components/modals/OpenModal.jsx
+++ b/src/components/modals/OpenModal.jsx
@@ -123,9 +123,8 @@ class OpenModal extends React.Component {
     })
   }
 
-  onOpenUrl = () => {
-    const url = this.styleUrlElement.value;
-    this.onStyleSelect(url);
+  onOpenUrl = (url) => {
+    this.onStyleSelect(this.state.styleUrl);
   }
 
   onUpload = (_, files) => {

--- a/src/components/modals/OpenModal.jsx
+++ b/src/components/modals/OpenModal.jsx
@@ -4,6 +4,7 @@ import LoadingModal from './LoadingModal'
 import Modal from './Modal'
 import Button from '../Button'
 import FileReaderInput from 'react-file-reader-input'
+import UrlInput from '../inputs/UrlInput'
 
 import {MdFileUpload} from 'react-icons/md'
 import {MdAddCircleOutline} from 'react-icons/md'
@@ -160,9 +161,9 @@ class OpenModal extends React.Component {
     this.props.onOpenToggle();
   }
 
-  onChangeUrl = () => {
+  onChangeUrl = (url) => {
     this.setState({
-      styleUrl: this.styleUrlElement.value
+      styleUrl: url,
     });
   }
 
@@ -209,14 +210,13 @@ class OpenModal extends React.Component {
             <p>
               Load from a URL. Note that the URL must have <a href="https://enable-cors.org" target="_blank" rel="noopener noreferrer">CORS enabled</a>.
             </p>
-            <input
+            <UrlInput
               data-wd-key="open-modal.url.input"
               type="text"
-              ref={(input) => this.styleUrlElement = input}
               className="maputnik-input"
-              placeholder="Enter URL..."
+              default="Enter URL..."
               value={this.state.styleUrl}
-              onChange={this.onChangeUrl}
+              onInput={this.onChangeUrl}
             />
             <div>
               <Button

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -6,6 +6,7 @@ import InputBlock from '../inputs/InputBlock'
 import ArrayInput from '../inputs/ArrayInput'
 import NumberInput from '../inputs/NumberInput'
 import StringInput from '../inputs/StringInput'
+import UrlInput from '../inputs/UrlInput'
 import SelectInput from '../inputs/SelectInput'
 import EnumInput from '../inputs/EnumInput'
 import ColorField from '../fields/ColorField'
@@ -100,7 +101,7 @@ class SettingsModal extends React.Component {
         />
       </InputBlock>
       <InputBlock label={"Sprite URL"} doc={latest.$root.sprite.doc}>
-        <StringInput {...inputProps}
+        <UrlInput {...inputProps}
           data-wd-key="modal-settings.sprite" 
           value={this.props.mapStyle.sprite}
           onChange={this.changeStyleProperty.bind(this, "sprite")}
@@ -108,7 +109,7 @@ class SettingsModal extends React.Component {
       </InputBlock>
 
       <InputBlock label={"Glyphs URL"} doc={latest.$root.glyphs.doc}>
-        <StringInput {...inputProps}
+        <UrlInput {...inputProps}
           data-wd-key="modal-settings.glyphs" 
           value={this.props.mapStyle.glyphs}
           onChange={this.changeStyleProperty.bind(this, "glyphs")}

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -85,7 +85,7 @@ class SettingsModal extends React.Component {
       onOpenToggle={this.props.onOpenToggle}
       title={'Style Settings'}
     >
-      <div style={{minWidth: 350}}>
+      <div className="modal-settings">
       <InputBlock label={"Name"} doc={latest.$root.name.doc}>
         <StringInput {...inputProps}
           data-wd-key="modal-settings.name" 

--- a/src/components/modals/SourcesModal.jsx
+++ b/src/components/modals/SourcesModal.jsx
@@ -112,10 +112,12 @@ class AddSource extends React.Component {
 
   defaultSource(mode) {
     const source = (this.state || {}).source || {}
+    const {protocol} = window.location;
+
     switch(mode) {
       case 'geojson_url': return {
         type: 'geojson',
-        data: 'http://localhost:3000/geojson.json'
+        data: `${protocol}//localhost:3000/geojson.json`
       }
       case 'geojson_json': return {
         type: 'geojson',
@@ -123,36 +125,48 @@ class AddSource extends React.Component {
       }
       case 'tilejson_vector': return {
         type: 'vector',
-        url: source.url || 'http://localhost:3000/tilejson.json'
+        url: source.url || `${protocol}//localhost:3000/tilejson.json`
       }
       case 'tilexyz_vector': return {
         type: 'vector',
-        tiles: source.tiles || ['http://localhost:3000/{x}/{y}/{z}.pbf'],
+        tiles: source.tiles || [`${protocol}//localhost:3000/{x}/{y}/{z}.pbf`],
         minZoom: source.minzoom || 0,
         maxZoom: source.maxzoom || 14
       }
       case 'tilejson_raster': return {
         type: 'raster',
-        url: source.url || 'http://localhost:3000/tilejson.json'
+        url: source.url || `${protocol}//localhost:3000/tilejson.json`
       }
       case 'tilexyz_raster': return {
         type: 'raster',
-        tiles: source.tiles || ['http://localhost:3000/{x}/{y}/{z}.pbf'],
+        tiles: source.tiles || [`${protocol}//localhost:3000/{x}/{y}/{z}.pbf`],
         minzoom: source.minzoom || 0,
         maxzoom: source.maxzoom || 14
       }
       case 'tilejson_raster-dem': return {
         type: 'raster-dem',
-        url: source.url || 'http://localhost:3000/tilejson.json'
+        url: source.url || `${protocol}//localhost:3000/tilejson.json`
       }
       case 'tilexyz_raster-dem': return {
         type: 'raster-dem',
-        tiles: source.tiles || ['http://localhost:3000/{x}/{y}/{z}.pbf'],
+        tiles: source.tiles || [`${protocol}//localhost:3000/{x}/{y}/{z}.pbf`],
         minzoom: source.minzoom || 0,
         maxzoom: source.maxzoom || 14
       }
       default: return {}
     }
+  }
+
+  onAdd = () => {
+    this.props.onAdd(this.state.sourceId, this.state.source);
+  }
+
+  onChangeSource = (source) => {
+    // let error = "CORs policy won't allow fetching resources served over http from https";
+    this.setState({
+      source,
+      error,
+    });
   }
 
   render() {
@@ -180,13 +194,20 @@ class AddSource extends React.Component {
         />
       </InputBlock>
       <SourceTypeEditor
-        onChange={src => this.setState({ source: src })}
+        onChange={this.onChangeSource}
         mode={this.state.mode}
         source={this.state.source}
       />
+      {this.state.error &&
+        <div className="maputnik-add-source-error" style={{fontSize: "12px", color: "#E57373"}}>
+          Error: {this.state.error}
+        </div>
+      }
       <Button
         className="maputnik-add-source-button"
-				onClick={() => this.props.onAdd(this.state.sourceId, this.state.source)}>
+				onClick={this.onAdd}
+        disabled={!!this.state.error}
+      >
         Add Source
       </Button>
     </div>

--- a/src/components/modals/SourcesModal.jsx
+++ b/src/components/modals/SourcesModal.jsx
@@ -158,15 +158,12 @@ class AddSource extends React.Component {
   }
 
   onAdd = () => {
-    this.props.onAdd(this.state.sourceId, this.state.source);
+    const {source, sourceId} = this.state;
+    this.props.onAdd(sourceId, source);
   }
 
   onChangeSource = (source) => {
-    // let error = "CORs policy won't allow fetching resources served over http from https";
-    this.setState({
-      source,
-      error,
-    });
+    this.setState({source});
   }
 
   render() {
@@ -198,15 +195,9 @@ class AddSource extends React.Component {
         mode={this.state.mode}
         source={this.state.source}
       />
-      {this.state.error &&
-        <div className="maputnik-add-source-error" style={{fontSize: "12px", color: "#E57373"}}>
-          Error: {this.state.error}
-        </div>
-      }
       <Button
         className="maputnik-add-source-button"
 				onClick={this.onAdd}
-        disabled={!!this.state.error}
       >
         Add Source
       </Button>

--- a/src/components/sources/SourceTypeEditor.jsx
+++ b/src/components/sources/SourceTypeEditor.jsx
@@ -96,7 +96,7 @@ class GeoJSONSourceUrlEditor extends React.Component {
 
   render() {
     return <InputBlock label={"GeoJSON URL"} doc={latest.source_geojson.data.doc}>
-      <StringInput
+      <UrlInput
         value={this.props.source.data}
         onChange={data => this.props.onChange({
           ...this.props.source,

--- a/src/components/sources/SourceTypeEditor.jsx
+++ b/src/components/sources/SourceTypeEditor.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import {latest} from '@mapbox/mapbox-gl-style-spec'
 import InputBlock from '../inputs/InputBlock'
 import StringInput from '../inputs/StringInput'
+import UrlInput from '../inputs/UrlInput'
 import NumberInput from '../inputs/NumberInput'
 import SelectInput from '../inputs/SelectInput'
 import JSONEditor from '../layers/JSONEditor'
@@ -18,7 +19,7 @@ class TileJSONSourceEditor extends React.Component {
   render() {
     return <div>
       <InputBlock label={"TileJSON URL"} doc={latest.source_vector.url.doc}>
-        <StringInput
+        <UrlInput
           value={this.props.source.url}
           onChange={url => this.props.onChange({
             ...this.props.source,
@@ -52,7 +53,7 @@ class TileURLSourceEditor extends React.Component {
     const tiles = this.props.source.tiles || []
     return tiles.map((tileUrl, tileIndex) => {
       return <InputBlock key={tileIndex} label={prefix[tileIndex] + " Tile URL"} doc={latest.source_vector.tiles.doc}>
-        <StringInput
+        <UrlInput
           value={tileUrl}
           onChange={this.changeTileUrl.bind(this, tileIndex)}
         />

--- a/src/components/util/SmallError.jsx
+++ b/src/components/util/SmallError.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import './SmallError.scss';
+
+
+class SmallError extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  render () {
+    return (
+      <div className="SmallError">
+        Error: {this.props.children}
+      </div>
+    );
+  }
+}
+
+export default SmallError

--- a/src/components/util/SmallError.scss
+++ b/src/components/util/SmallError.scss
@@ -1,0 +1,7 @@
+@import '../../styles/vars';
+
+.SmallError {
+  color: #E57373;
+  font-size: $font-size-5;
+  margin-top: $margin-2
+}

--- a/src/components/util/SmallError.scss
+++ b/src/components/util/SmallError.scss
@@ -2,6 +2,6 @@
 
 .SmallError {
   color: #E57373;
-  font-size: $font-size-5;
+  font-size: $font-size-6;
   margin-top: $margin-2
 }

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -280,3 +280,7 @@
   color: $color-green;
   margin-top: 16px;
 }
+
+.modal-settings {
+  width: 400px;
+}

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -1,0 +1,23 @@
+$color-black: #191b20;
+$color-gray: #222429;
+$color-midgray: #303237;
+$color-lowgray: #a4a4a4;
+$color-white: #f0f0f0;
+$color-red: #cf4a4a;
+$color-green: #53b972;
+$margin-1: 3px;
+$margin-2: 5px;
+$margin-3: 10px;
+$margin-4: 30px;
+$margin-5: 40px;
+$font-size-1: 24px;
+$font-size-2: 20px;
+$font-size-3: 18px;
+$font-size-4: 16px;
+$font-size-5: 14px;
+$font-size-6: 12px;
+$font-family: Roboto, sans-serif;
+
+$toolbar-height: 40px;
+$toolbar-offset: 0;
+

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,26 +1,4 @@
-$color-black: #191b20;
-$color-gray: #222429;
-$color-midgray: #303237;
-$color-lowgray: #a4a4a4;
-$color-white: #f0f0f0;
-$color-red: #cf4a4a;
-$color-green: #53b972;
-$margin-1: 3px;
-$margin-2: 5px;
-$margin-3: 10px;
-$margin-4: 30px;
-$margin-5: 40px;
-$font-size-1: 24px;
-$font-size-2: 20px;
-$font-size-3: 18px;
-$font-size-4: 16px;
-$font-size-5: 14px;
-$font-size-6: 12px;
-$font-family: Roboto, sans-serif;
-
-$toolbar-height: 40px;
-$toolbar-offset: 0;
-
+@import 'vars';
 @import 'mixins';
 @import 'reset';
 @import 'base';


### PR DESCRIPTION
If the editor is loaded from `https://` (like on `https://maputnik.github.io/editor/`) show an error for url fields where the user is trying to use `http://` urls 

Demo: <https://1815-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html>

<img width="602" alt="Screen Shot 2019-10-27 at 17 47 54" src="https://user-images.githubusercontent.com/235915/67638938-0dd6f780-f8e2-11e9-8fee-98ff792adf52.png">
<img width="603" alt="Screen Shot 2019-10-27 at 17 48 12" src="https://user-images.githubusercontent.com/235915/67638939-10395180-f8e2-11e9-88fb-8ba1020388d4.png">

Fixes #374 
