### PR TITLE
Add matchbrackets addon to JSON editor

### DIFF
--- a/src/codemirror-maputnik.css
+++ b/src/codemirror-maputnik.css
@@ -47,5 +47,5 @@
 }
 
 .cm-s-maputnik .CodeMirror-matchingbracket {
-  text-decoration: underline; color: white !important;
+  color: white !important;
 }

--- a/src/codemirror-maputnik.css
+++ b/src/codemirror-maputnik.css
@@ -17,7 +17,7 @@
 }
 
 .cm-s-maputnik .CodeMirror-cursor {
-    border-left: solid thin #8e8e8e !important;
+    border-left: solid thin #f0f0f0 !important;
 }
 
 .cm-s-maputnik.CodeMirror-focused div.CodeMirror-selected {
@@ -47,5 +47,11 @@
 }
 
 .cm-s-maputnik .CodeMirror-matchingbracket {
+  background-color: #f0f0f0;  
+  color: #565659 !important;
+}
+
+.cm-s-maputnik .CodeMirror-nonmatchingbracket {
+  background-color: #bb0000;  
   color: white !important;
 }

--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -7,6 +7,7 @@ import CodeMirror from 'codemirror';
 
 import 'codemirror/mode/javascript/javascript'
 import 'codemirror/addon/lint/lint'
+import 'codemirror/addon/edit/matchbrackets'
 import 'codemirror/lib/codemirror.css'
 import 'codemirror/addon/lint/lint.css'
 import '../../codemirror-maputnik.css'
@@ -47,6 +48,7 @@ class JSONEditor extends React.Component {
       viewportMargin: Infinity,
       lineNumbers: true,
       lint: true,
+      matchBrackets: true,
       gutters: ["CodeMirror-lint-markers"],
       scrollbarStyle: "null",
     });
@@ -112,6 +114,7 @@ class JSONEditor extends React.Component {
       viewportMargin: Infinity,
       lineNumbers: true,
       lint: true,
+      matchBrackets: true,
       gutters: ["CodeMirror-lint-markers"],
       scrollbarStyle: "null",
     }


### PR DESCRIPTION
When the JSON editor was added in https://github.com/maputnik/editor/commit/3cc9f450850deda37bdb193052a742b5ca105376, there was already styling for the codemirror `matchbrackets` addon defined but the addon itself was never added.

This PR adds this addon and removes the `text-decoration: underline` from CSS (it looked a bit weird because the underline was not fully visible).

~~Demo: https://2039-67726921-gh.circle-artifacts.com/0/artifacts/build/index.html~~





