### PR TITLE
Increase maximum zoom level of the map to 24

### DIFF
--- a/src/components/map/MapboxGlMap.jsx
+++ b/src/components/map/MapboxGlMap.jsx
@@ -124,6 +124,7 @@ export default class MapboxGlMap extends React.Component {
       container: this.container,
       style: this.props.mapStyle,
       hash: true,
+      maxZoom: 24
     }
 
     const map = new MapboxGl.Map(mapOpts);


### PR DESCRIPTION
Closes https://github.com/maputnik/editor/issues/593

Overwrites the default `maxZoom` of 22:
https://docs.mapbox.com/mapbox-gl-js/api/#map

**Demo:**
https://2055-67726921-gh.circle-artifacts.com/0/artifacts/build/index.html



