### PR TITLE
Remove node v8 from test runners 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,6 @@ templates:
         path: /tmp/artifacts
         destination: /artifacts
 jobs:
-  build-linux-node-v8:
-    docker:
-      - image: node:8
-    working_directory: ~/repo-linux-node-v8
-    steps: *build-steps
   build-linux-node-v10:
     docker:
       - image: node:10
@@ -70,14 +65,6 @@ jobs:
     docker:
       - image: node:13
     working_directory: ~/repo-linux-node-v13
-    steps: *build-steps
-  build-osx-node-v8:
-    macos:
-      xcode: "9.0"
-    dependencies:
-      override:
-        - brew install node@8
-    working_directory: ~/repo-osx-node-v8
     steps: *build-steps
   build-osx-node-v10:
     macos:
@@ -108,11 +95,9 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-linux-node-v8
       - build-linux-node-v10
       - build-linux-node-v12
       - build-linux-node-v13
-      - build-osx-node-v8
       - build-osx-node-v10
       - build-osx-node-v12
       - build-osx-node-v13

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 image: Visual Studio 2015
 environment:
   matrix:
-    - nodejs_version: "8"
     - nodejs_version: "10"
     - nodejs_version: "12"
     - nodejs_version: "13"


### PR DESCRIPTION
Node v8 is EOL: https://github.com/nodejs/Release#end-of-life-releases