### PR TITLE
Update react-collapse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9070,12 +9070,9 @@
       }
     },
     "react-collapse": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-4.0.3.tgz",
-      "integrity": "sha512-OO4NhtEqFtz+1ma31J1B7+ezdRnzHCZiTGSSd/Pxoks9hxrZYhzFEddeYt05A/1477xTtdrwo7xEa2FLJyWGCQ==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.0.1.tgz",
+      "integrity": "sha512-cN2tkxBWizhPQ2JHfe0aUSJtmMthKA17NZkTElpiQ2snQAAi1hssXZ2fv88rAPNNvG5ss4t0PbOZT0TIl9Lk3Q=="
     },
     "react-color": {
       "version": "2.17.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-aria-modal": "^4.0.0",
     "react-autobind": "^1.0.6",
     "react-autocomplete": "^1.8.1",
-    "react-collapse": "^4.0.3",
+    "react-collapse": "^5.0.1",
     "react-color": "^2.17.3",
     "react-dom": "^16.10.2",
     "react-file-reader-input": "^2.0.0",

--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -105,17 +105,6 @@ class JSONEditor extends React.Component {
   }
 
   render() {
-    const codeMirrorOptions = {
-      mode: {name: "javascript", json: true},
-      tabSize: 2,
-      theme: 'maputnik',
-      viewportMargin: Infinity,
-      lineNumbers: true,
-      lint: true,
-      gutters: ["CodeMirror-lint-markers"],
-      scrollbarStyle: "null",
-    }
-
     const style = {};
     if (this.props.maxHeight) {
       style.maxHeight = this.props.maxHeight;

--- a/src/styles/_react-collapse.scss
+++ b/src/styles/_react-collapse.scss
@@ -7,3 +7,7 @@
     flex: 1;
   }
 }
+
+.ReactCollapse--collapse {
+  transition: height 180ms;
+}


### PR DESCRIPTION
I believe this fixes #565 

`react-collapse` was updating the DOM resetting the scroll position of the collapsible element, which was causing the scroll position jump in the pane. The new version of `react-collapse` seems to fix this issue.

There is a demo ready for testing: <https://1910-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html>