### PR TITLE
Added ability to add image/video sources

### DIFF
--- a/src/components/modals/SourcesModal.jsx
+++ b/src/components/modals/SourcesModal.jsx
@@ -60,6 +60,12 @@ function editorMode(source) {
       return 'geojson_json';
     }
   }
+  if(source.type === 'image') {
+    return 'image';
+  }
+  if(source.type === 'video') {
+    return 'video';
+  }
   return null
 }
 
@@ -153,6 +159,28 @@ class AddSource extends React.Component {
         minzoom: source.minzoom || 0,
         maxzoom: source.maxzoom || 14
       }
+      case 'image': return {
+        type: 'image',
+        url: `${protocol}//localhost:3000/image.png`,
+        coordinates: [
+          [0,0],
+          [0,0],
+          [0,0],
+          [0,0],
+        ],
+      }
+      case 'video': return {
+        type: 'video',
+        urls: [
+          `${protocol}//localhost:3000/movie.mp4`
+        ],
+        coordinates: [
+          [0,0],
+          [0,0],
+          [0,0],
+          [0,0],
+        ],
+      }
       default: return {}
     }
   }
@@ -185,6 +213,8 @@ class AddSource extends React.Component {
             ['tilexyz_raster', 'Raster (XYZ URL)'],
             ['tilejson_raster-dem', 'Raster DEM (TileJSON URL)'],
             ['tilexyz_raster-dem', 'Raster DEM (XYZ URLs)'],
+            ['image', 'Image'],
+            ['video', 'Video'],
           ]}
           onChange={mode => this.setState({mode: mode, source: this.defaultSource(mode)})}
           value={this.state.mode}

--- a/src/components/sources/SourceTypeEditor.jsx
+++ b/src/components/sources/SourceTypeEditor.jsx
@@ -117,7 +117,7 @@ class ImageSourceEditor extends React.Component {
           })}
         />
       </InputBlock>
-      {["top", "left", "bottom", "right"].map((label, idx) => {
+      {["top left", "top right", "bottom right", "bottom left"].map((label, idx) => {
         return (
           <InputBlock label={`Coord ${label}`} key={label}>
             <ArrayInput
@@ -167,7 +167,7 @@ class VideoSourceEditor extends React.Component {
           onChange={changeUrls}
         />
       </InputBlock>
-      {["top", "left", "bottom", "right"].map((label, idx) => {
+      {["top left", "top right", "bottom right", "bottom left"].map((label, idx) => {
         return (
           <InputBlock label={`Coord ${label}`} key={label}>
             <ArrayInput

--- a/src/components/sources/SourceTypeEditor.jsx
+++ b/src/components/sources/SourceTypeEditor.jsx
@@ -6,6 +6,8 @@ import StringInput from '../inputs/StringInput'
 import UrlInput from '../inputs/UrlInput'
 import NumberInput from '../inputs/NumberInput'
 import SelectInput from '../inputs/SelectInput'
+import DynamicArrayInput from '../inputs/DynamicArrayInput'
+import ArrayInput from '../inputs/ArrayInput'
 import JSONEditor from '../layers/JSONEditor'
 
 
@@ -88,6 +90,100 @@ class TileURLSourceEditor extends React.Component {
   }
 }
 
+class ImageSourceEditor extends React.Component {
+  static propTypes = {
+    source: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+  }
+
+  render() {
+    const changeCoord = (idx, val) => {
+      const coordinates = this.props.source.coordinates.slice(0);
+      coordinates[idx] = val;
+
+      this.props.onChange({
+        ...this.props.source,
+        coordinates,
+      });
+    }
+
+    return <div>
+      <InputBlock label={"Image URL"} doc={latest.source_image.url.doc}>
+        <UrlInput
+          value={this.props.source.url}
+          onChange={url => this.props.onChange({
+            ...this.props.source,
+            url,
+          })}
+        />
+      </InputBlock>
+      {["top", "left", "bottom", "right"].map((label, idx) => {
+        return (
+          <InputBlock label={`Coord ${label}`} key={label}>
+            <ArrayInput
+              length={2}
+              type="number"
+              value={this.props.source.coordinates[idx]}
+              default={[0, 0]}
+              onChange={(val) => changeCoord(idx, val)}
+            />
+          </InputBlock>
+        );
+      })}
+    </div>
+  }
+}
+
+class VideoSourceEditor extends React.Component {
+  static propTypes = {
+    source: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+  }
+
+  render() {
+    const changeCoord = (idx, val) => {
+      const coordinates = this.props.source.coordinates.slice(0);
+      coordinates[idx] = val;
+
+      this.props.onChange({
+        ...this.props.source,
+        coordinates,
+      });
+    }
+
+    const changeUrls = (urls) => {
+      this.props.onChange({
+        ...this.props.source,
+        urls,
+      });
+    }
+
+    return <div>
+      <InputBlock label={"Video URL"} doc={latest.source_video.urls.doc}>
+        <DynamicArrayInput
+          type="string"
+          value={this.props.source.urls}
+          default={""}
+          onChange={changeUrls}
+        />
+      </InputBlock>
+      {["top", "left", "bottom", "right"].map((label, idx) => {
+        return (
+          <InputBlock label={`Coord ${label}`} key={label}>
+            <ArrayInput
+              length={2}
+              type="number"
+              value={this.props.source.coordinates[idx]}
+              default={[0, 0]}
+              onChange={val => changeCoord(idx, val)}
+            />
+          </InputBlock>
+        );
+      })}
+    </div>
+  }
+}
+
 class GeoJSONSourceUrlEditor extends React.Component {
   static propTypes = {
     source: PropTypes.object.isRequired,
@@ -161,6 +257,8 @@ class SourceTypeEditor extends React.Component {
           />
         </InputBlock>
       </TileURLSourceEditor>
+      case 'image': return <ImageSourceEditor {...commonProps} />
+      case 'video': return <VideoSourceEditor {...commonProps} />
       default: return null
     }
   }

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -138,6 +138,7 @@
     user-select: none;
     width: 50%;
     vertical-align: top;
+    font-size: 12px;
   }
 
   &-content {


### PR DESCRIPTION
This PR adds the ability to add image/video sources

Demo: https://1971-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html

Adding images/video from

 - https://docs.mapbox.com/mapbox-gl-js/example/image-on-a-map/
 - https://docs.mapbox.com/mapbox-gl-js/example/video-on-a-map/

<img width="622" alt="Screenshot 2020-01-19 at 15 47 38" src="https://user-images.githubusercontent.com/235915/72683845-303c7380-3ad3-11ea-9399-fa9e33e608ea.png">
<img width="1080" alt="Screenshot 2020-01-19 at 14 34 59" src="https://user-images.githubusercontent.com/235915/72683851-3a5e7200-3ad3-11ea-8c42-f9e3ea104b3c.png">
<img width="1079" alt="Screenshot 2020-01-19 at 14 34 08" src="https://user-images.githubusercontent.com/235915/72683852-3cc0cc00-3ad3-11ea-904f-c73c1b418032.png">

Notes:

 - Coordinate fields could definitely to with UI/UX improvements as they take up a lot of vertical space at the moment. I think a later addition 
 - The sources tab doesn't currently display the 'type' of the source once added. This is an existing issue and will be fixed separately
 - When adding a new source the inputs don't get cleared. This is an existing issue and will be fixed separately