### PR TITLE
Link to OSM from debug panel

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -212,6 +212,13 @@ export default class App extends React.Component {
       vectorLayers: {},
       mapState: "map",
       spec: latest,
+      mapView: {
+        zoom: 0,
+        center: {
+          lng: 0,
+          lat: 0,
+        },
+      },
       isOpen: {
         settings: false,
         sources: false,
@@ -531,11 +538,22 @@ export default class App extends React.Component {
     return metadata['maputnik:renderer'] || 'mbgljs';
   }
 
+  onMapChange = (mapView) => {
+    this.setState({
+      mapView,
+    });
+  }
+
   mapRenderer() {
     const metadata = this.state.mapStyle.metadata || {};
 
     const mapProps = {
-      mapStyle: style.replaceAccessTokens(this.state.mapStyle, {allowFallback: true}),
+      mapStyle: this.state.mapStyle,
+      replaceAccessTokens: (mapStyle) => {
+        return style.replaceAccessTokens(mapStyle, {
+          allowFallback: true
+        });
+      },
       onDataChange: (e) => {
         this.layerWatcher.analyzeMap(e.map)
         this.fetchSources();
@@ -550,11 +568,13 @@ export default class App extends React.Component {
     if(renderer === 'ol') {
       mapElement = <OpenLayersMap
         {...mapProps}
+        onChange={this.onMapChange}
         debugToolbox={this.state.openlayersDebugOptions.debugToolbox}
         onLayerSelect={this.onLayerSelect}
       />
     } else {
       mapElement = <MapboxGlMap {...mapProps}
+        onChange={this.onMapChange}
         options={this.state.mapboxGlDebugOptions}
         inspectModeEnabled={this.state.mapState === "inspect"}
         highlightedLayer={this.state.mapStyle.layers[this.state.selectedLayerIndex]}
@@ -676,6 +696,7 @@ export default class App extends React.Component {
         onChangeOpenlayersDebug={this.onChangeOpenlayersDebug}
         isOpen={this.state.isOpen.debug}
         onOpenToggle={this.toggleModal.bind(this, 'debug')}
+        mapView={this.state.mapView}
       />
       <ShortcutsModal
         ref={(el) => this.shortcutEl = el}

--- a/src/components/map/MapboxGlMap.jsx
+++ b/src/components/map/MapboxGlMap.jsx
@@ -66,6 +66,7 @@ export default class MapboxGlMap extends React.Component {
     onMapLoaded: () => {},
     onDataChange: () => {},
     onLayerSelect: () => {},
+    onChange: () => {},
     mapboxAccessToken: tokens.mapbox,
     options: {},
   }
@@ -128,12 +129,21 @@ export default class MapboxGlMap extends React.Component {
 
     const map = new MapboxGl.Map(mapOpts);
 
+    const center = map.getCenter();
+    const zoom = map.getZoom();
+
+    this.setState({
+      center,
+      zoom,
+    });
+    this.props.onChange({center, zoom});
+
     map.showTileBoundaries = mapOpts.showTileBoundaries;
     map.showCollisionBoxes = mapOpts.showCollisionBoxes;
     map.showOverdrawInspector = mapOpts.showOverdrawInspector;
 
-    const zoom = new ZoomControl;
-    map.addControl(zoom, 'top-right');
+    const zoomControl = new ZoomControl;
+    map.addControl(zoomControl, 'top-right');
 
     const nav = new MapboxGl.NavigationControl({visualizePitch:true});
     map.addControl(nav, 'top-right');
@@ -189,7 +199,21 @@ export default class MapboxGlMap extends React.Component {
       this.setState({
         zoom: map.getZoom()
       });
-    })
+    });
+
+    map.on("dragend", e => {
+      this.props.onChange({
+        center: map.getCenter(),
+        zoom: this.state.zoom,
+      })
+    });
+
+    map.on("zoomend", e => {
+      this.props.onChange({
+        center: this.state.center,
+        zoom: map.getZoom(),
+      })
+    });
   }
 
   render() {

--- a/src/components/map/MapboxGlMap.jsx
+++ b/src/components/map/MapboxGlMap.jsx
@@ -60,6 +60,7 @@ export default class MapboxGlMap extends React.Component {
     inspectModeEnabled: PropTypes.bool.isRequired,
     highlightedLayer: PropTypes.object,
     options: PropTypes.object,
+    replaceAccessTokens: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
   }
 
@@ -90,7 +91,10 @@ export default class MapboxGlMap extends React.Component {
 
     //Mapbox GL now does diffing natively so we don't need to calculate
     //the necessary operations ourselves!
-    this.state.map.setStyle(props.mapStyle, {diff: true})
+    this.state.map.setStyle(
+      this.props.replaceAccessTokens(props.mapStyle),
+      {diff: true}
+    )
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/map/MapboxGlMap.jsx
+++ b/src/components/map/MapboxGlMap.jsx
@@ -134,14 +134,12 @@ export default class MapboxGlMap extends React.Component {
 
     const map = new MapboxGl.Map(mapOpts);
 
-    const center = map.getCenter();
-    const zoom = map.getZoom();
-
-    this.setState({
-      center,
-      zoom,
-    });
-    this.props.onChange({center, zoom});
+    const mapViewChange = () => {
+      const center = map.getCenter();
+      const zoom = map.getZoom();
+      this.props.onChange({center, zoom});
+    }
+    mapViewChange();
 
     map.showTileBoundaries = mapOpts.showTileBoundaries;
     map.showCollisionBoxes = mapOpts.showCollisionBoxes;
@@ -206,19 +204,8 @@ export default class MapboxGlMap extends React.Component {
       });
     });
 
-    map.on("dragend", e => {
-      this.props.onChange({
-        center: map.getCenter(),
-        zoom: this.state.zoom,
-      })
-    });
-
-    map.on("zoomend", e => {
-      this.props.onChange({
-        center: this.state.center,
-        zoom: map.getZoom(),
-      })
-    });
+    map.on("dragend", mapViewChange);
+    map.on("zoomend", mapViewChange);
   }
 
   render() {

--- a/src/components/map/MapboxGlMap.jsx
+++ b/src/components/map/MapboxGlMap.jsx
@@ -60,6 +60,7 @@ export default class MapboxGlMap extends React.Component {
     inspectModeEnabled: PropTypes.bool.isRequired,
     highlightedLayer: PropTypes.object,
     options: PropTypes.object,
+    onChange: PropTypes.func.isRequired,
   }
 
   static defaultProps = {

--- a/src/components/map/OpenLayersMap.jsx
+++ b/src/components/map/OpenLayersMap.jsx
@@ -32,6 +32,8 @@ export default class OpenLayersMap extends React.Component {
     style: PropTypes.object,
     onLayerSelect: PropTypes.func.isRequired,
     debugToolbox: PropTypes.bool.isRequired,
+    replaceAccessTokens: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
   }
 
   static defaultProps = {

--- a/src/components/map/OpenLayersMap.jsx
+++ b/src/components/map/OpenLayersMap.jsx
@@ -61,7 +61,9 @@ export default class OpenLayersMap extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.mapStyle !== prevProps.mapStyle) {
-      this.updateStyle(this.props.mapStyle);
+      this.updateStyle(
+        this.props.replaceAccessTokens(this.props.mapStyle)
+      );
     }
   }
 
@@ -93,6 +95,22 @@ export default class OpenLayersMap extends React.Component {
       })
     })
 
+    const onMoveEnd = () => {
+      const zoom = map.getView().getZoom();
+      const center = toLonLat(map.getView().getCenter());
+
+      this.props.onChange({
+        zoom,
+        center: {
+          lng: center[0],
+          lat: center[1],
+        },
+      });
+    }
+
+    onMoveEnd();
+    map.on('moveend', onMoveEnd);
+
     map.on('postrender', (evt) => {
       const center = toLonLat(map.getView().getCenter());
       this.setState({
@@ -108,7 +126,9 @@ export default class OpenLayersMap extends React.Component {
 
 
     this.map = map;
-    this.updateStyle(this.props.mapStyle);
+    this.updateStyle(
+      this.props.replaceAccessTokens(this.props.mapStyle)
+    );
   }
 
   closeOverlay = (e) => {

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -13,9 +13,12 @@ class DebugModal extends React.Component {
     onOpenToggle: PropTypes.func.isRequired,
     mapboxGlDebugOptions: PropTypes.object,
     openlayersDebugOptions: PropTypes.object,
+    mapView: PropTypes.object,
   }
 
   render() {
+    const {mapView} = this.props;
+
     return <Modal
       data-wd-key="debug-modal"
       isOpen={this.props.isOpen}
@@ -23,6 +26,7 @@ class DebugModal extends React.Component {
       title={'Debug'}
     >
       <div className="maputnik-modal-section maputnik-modal-shortcuts">
+        <h4>Options</h4>
         {this.props.renderer === 'mbgljs' &&
           <ul>
             {Object.entries(this.props.mapboxGlDebugOptions).map(([key, val]) => {
@@ -45,6 +49,18 @@ class DebugModal extends React.Component {
             })}
           </ul>
         }
+      </div>
+      <div className="maputnik-modal-section">
+        <h4>Links</h4>
+        <p>
+          <a
+            target="_blank"
+            rel="noopener" or rel="noreferrer"
+            href={`https://www.openstreetmap.org/#map=${Math.round(mapView.zoom)+1}/${mapView.center.lat}/${mapView.center.lng}`}
+          >
+            Open in OSM
+          </a> &mdash; Opens the current view on openstreetmap.org
+        </p>
       </div>
     </Modal>
   }

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -55,7 +55,7 @@ class DebugModal extends React.Component {
         <p>
           <a
             target="_blank"
-            rel="noopener" or rel="noreferrer"
+            rel="noopener noreferrer"
             href={`https://www.openstreetmap.org/#map=${Math.round(mapView.zoom)+1}/${mapView.center.lat}/${mapView.center.lng}`}
           >
             Open in OSM

--- a/src/components/modals/DebugModal.js
+++ b/src/components/modals/DebugModal.js
@@ -19,6 +19,10 @@ class DebugModal extends React.Component {
   render() {
     const {mapView} = this.props;
 
+    const osmZoom = Math.round(mapView.zoom)+1;
+    const osmLon = Number.parseFloat(mapView.center.lng).toFixed(5);
+    const osmLat = Number.parseFloat(mapView.center.lat).toFixed(5);
+
     return <Modal
       data-wd-key="debug-modal"
       isOpen={this.props.isOpen}
@@ -56,7 +60,7 @@ class DebugModal extends React.Component {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={`https://www.openstreetmap.org/#map=${Math.round(mapView.zoom)+1}/${mapView.center.lat}/${mapView.center.lng}`}
+            href={`https://www.openstreetmap.org/#map=${osmZoom}/${osmLat}/${osmLon}`}
           >
             Open in OSM
           </a> &mdash; Opens the current view on openstreetmap.org


### PR DESCRIPTION
This adds a link to OSM `https://www.openstreetmap.org/#map={ZOOM}/{LAT}/{LNG}` from the debug panel

To open the debug panel focus the editor then press `ESC` follow by `!`

Demo: <https://1981-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html#0.36/0/0>

<img width="380" alt="Screenshot 2020-01-19 at 16 06 14" src="https://user-images.githubusercontent.com/235915/72684116-a80b9d80-3ad5-11ea-94e7-f5668c14af7c.png">
