### PR TITLE
Make background map container white to match html page default

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -1,5 +1,6 @@
 // MAP
 .maputnik-map__container {
+  background: white;
   display: flex;
   position: fixed !important;
   top: $toolbar-height + $toolbar-offset;


### PR DESCRIPTION
HTML pages start with a white background in most browsers, most articles which contain maps are also going to be on a white background. So if a style doesn't set a background layer at the moment the user will probably get a different outcome than they expect when they export the style.

Before, with 'Empty Style'
<img width="1280" alt="Screenshot 2020-02-02 at 11 52 13" src="https://user-images.githubusercontent.com/235915/73607790-a0a6c280-45b2-11ea-989e-49e87bfe792d.png">

After, with 'Empty Style' 
<img width="1280" alt="Screenshot 2020-02-02 at 11 51 56" src="https://user-images.githubusercontent.com/235915/73607792-a8fefd80-45b2-11ea-9373-257e4fcaf9ab.png">
