### PR TITLE
Fixed overflowing error bar

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -7,11 +7,7 @@
   right: 0;
   bottom: 0;
   height: calc(100% - #{$toolbar-height + $toolbar-offset});
-  width: calc(
-    100%
-    - 200px /* layer list */
-    - 350px /* layer editor */
-  );
+  width: $layout-map-width;
 
   &--error {
     align-items: center;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -40,9 +40,9 @@
     position: fixed;
     height: 50px;
     bottom: 0;
-    left: 550px;
+    right: 0;
     z-index: 1;
-    width: 100%;
+    width: $layout-map-width;
     background-color: $color-black;
   }
 }

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -21,3 +21,7 @@ $font-family: Roboto, sans-serif;
 $toolbar-height: 40px;
 $toolbar-offset: 0;
 
+$layout-list-width: 200px;
+$layout-editor-width: 370px;
+$layout-map-width: calc(100% - #{$layout-list-width + $layout-editor-width});
+


### PR DESCRIPTION
The error bar beneath the map was overflowing into the layer editor.

Before
<img width="233" alt="Screenshot 2020-02-09 at 17 24 52" src="https://user-images.githubusercontent.com/235915/74106765-2d2c2480-4b61-11ea-8a58-2e42ccd625b0.png">

After
<img width="318" alt="Screenshot 2020-02-09 at 17 24 22" src="https://user-images.githubusercontent.com/235915/74106766-2f8e7e80-4b61-11ea-9bdd-7b13fc3e06a1.png">
