### PR TITLE
Wider scrollbar

### DIFF
--- a/src/styles/_scrollbar.scss
+++ b/src/styles/_scrollbar.scss
@@ -2,7 +2,8 @@
 div:not(.maputnik-toolbar__actions) {
   &::-webkit-scrollbar {
     background-color: #26282e;
-    width: 5px;
+    width: 8px;
+    height: 8px;
   }
 
   &::-webkit-scrollbar-thumb {


### PR DESCRIPTION
I've moved from using a trackpad (no scrollbars) to a mouse (has scrollbars), and clicking/grabbing the scrollbar was a little awkward because it was so small (5px). This PR makes the scrollbar wider so it's easier to grab with the mouse pointer.

Note this only effects webkit browsers.