### PR TITLE
Remove notes from thunderforest sources

### DIFF
--- a/src/components/modals/SourcesModal.jsx
+++ b/src/components/modals/SourcesModal.jsx
@@ -303,9 +303,6 @@ class SourcesModal extends React.Component {
         <div className="maputnik-public-sources" style={{maxwidth: 500}}>
         {tilesetOptions}
         </div>
-        <p>
-          <strong>Note:</strong> Some of the tilesets are not optimised for online use, and as a result the file sizes of the tiles can be quite large (heavy) for online vector rendering. Please review any tilesets before use.
-        </p>
       </div>
 
       <div className="maputnik-modal-section">

--- a/src/config/tilesets.json
+++ b/src/config/tilesets.json
@@ -7,12 +7,12 @@
   "thunderforest_transport": {
     "type": "vector",
     "url": "https://tile.thunderforest.com/thunderforest.transport-v2.json?apikey={key}",
-    "title": "Thunderforest Transport v2 (heavy)"
+    "title": "Thunderforest Transport v2"
   },
   "thunderforest_outdoors": {
     "type": "vector",
     "url": "https://tile.thunderforest.com/thunderforest.outdoors-v2.json?apikey={key}",
-    "title": "Thunderforest Outdoors v2 (heavy)"
+    "title": "Thunderforest Outdoors v2"
   },
   "open_zoomstack": {
     "type": "vector",


### PR DESCRIPTION
Thunderforest tiles are no longer 'heavy' as of v2 🎉(see https://github.com/maputnik/editor/issues/641#issuecomment-612593093)

Removed all references from 'heavy' from the UI.