### PR TITLE
Fixed default values for <FontInput/>

### DIFF
--- a/src/components/inputs/FontInput.jsx
+++ b/src/components/inputs/FontInput.jsx
@@ -4,7 +4,7 @@ import AutocompleteInput from './AutocompleteInput'
 
 class FontInput extends React.Component {
   static propTypes = {
-    value: PropTypes.array.isRequired,
+    value: PropTypes.array,
     default: PropTypes.array,
     fonts: PropTypes.array,
     style: PropTypes.object,
@@ -16,7 +16,7 @@ class FontInput extends React.Component {
   }
 
   get values() {
-    const out = this.props.value || this.props.default.slice(1) || [""];
+    const out = this.props.value || this.props.default || [];
 
     // Always put a "" in the last field to you can keep adding entries
     if (out[out.length-1] !== ""){


### PR DESCRIPTION
Fixes default values for `<FontInput/>`, it was previously was only picking up the first value of the array of values.

Demo <https://2502-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html>

Fixes #649 