### PR TITLE
Added missing inline error for 'source' field

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -345,6 +345,7 @@ export default class App extends React.Component {
     }
 
     const mappedErrors = layerErrors.concat(errors).map(error => {
+      // Special case: Duplicate layer id
       const dupMatch = error.message.match(/layers\[(\d+)\]: (duplicate layer id "?(.*)"?, previously used)/);
       if (dupMatch) {
         const [matchStr, index, message] = dupMatch;
@@ -361,7 +362,23 @@ export default class App extends React.Component {
         }
       }
 
-      // duplicate layer id
+      // Special case: Invalid source
+      const invalidSourceMatch = error.message.match(/layers\[(\d+)\]: (source "(?:.*)" not found)/);
+      if (invalidSourceMatch) {
+        const [matchStr, index, message] = invalidSourceMatch;
+        return {
+          message: error.message,
+          parsed: {
+            type: "layer",
+            data: {
+              index: parseInt(index, 10),
+              key: "source",
+              message,
+            }
+          }
+        }
+      }
+
       const layerMatch = error.message.match(/layers\[(\d+)\]\.(?:(\S+)\.)?(\S+): (.*)/);
       if (layerMatch) {
         const [matchStr, index, group, property, message] = layerMatch;

--- a/src/components/layers/LayerEditor.jsx
+++ b/src/components/layers/LayerEditor.jsx
@@ -168,7 +168,7 @@ export default class LayerEditor extends React.Component {
           )}
         />
         {this.props.layer.type !== 'background' && <LayerSourceBlock
-          error={errorData.sources}
+          error={errorData.source}
           sourceIds={Object.keys(this.props.sources)}
           value={this.props.layer.source}
           onChange={v => this.changeProperty(null, 'source', v)}

--- a/src/components/layers/LayerSourceBlock.jsx
+++ b/src/components/layers/LayerSourceBlock.jsx
@@ -11,6 +11,7 @@ class LayerSourceBlock extends React.Component {
     wdKey: PropTypes.string,
     onChange: PropTypes.func,
     sourceIds: PropTypes.array,
+    error: PropTypes.object,
   }
 
   static defaultProps = {
@@ -19,7 +20,10 @@ class LayerSourceBlock extends React.Component {
   }
 
   render() {
-    return <InputBlock label={"Source"} fieldSpec={latest.layer.source}
+    return <InputBlock
+      label={"Source"}
+      fieldSpec={latest.layer.source}
+      error={this.props.error}
       data-wd-key={this.props.wdKey}
     >
       <AutocompleteInput


### PR DESCRIPTION
Adds missing inline error for 'source' field.

<img width="374" alt="Screenshot 2020-04-13 at 09 15 34" src="https://user-images.githubusercontent.com/235915/79104862-5d619080-7d67-11ea-9b0b-375769fa4364.png">

Demo <https://2508-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html>

Fixes #653 
