### PR TITLE
Added JSON linting back into <SourceTypeEditor/>

### DIFF
--- a/src/components/sources/SourceTypeEditor.jsx
+++ b/src/components/sources/SourceTypeEditor.jsx
@@ -214,6 +214,11 @@ class GeoJSONSourceJSONEditor extends React.Component {
       <JSONEditor
         layer={this.props.source.data}
         maxHeight={200}
+        mode={{
+          name: "javascript",
+          json: true
+        }}
+        lint={true}
         onChange={data => {
           this.props.onChange({
             ...this.props.source,

--- a/src/components/util/codemirror-mgl.js
+++ b/src/components/util/codemirror-mgl.js
@@ -12,6 +12,30 @@ CodeMirror.defineMode("mgl", function(config, parserConfig) {
   );
 });
 
+CodeMirror.registerHelper("lint", "json", function(text) {
+  const found = [];
+
+  // NOTE: This was modified from the original to remove the global, also the
+  // old jsonlint API was 'jsonlint.parseError' its now
+  // 'jsonlint.parser.parseError'
+  jsonlint.parser.parseError = function(str, hash) {
+    const loc = hash.loc;
+    found.push({
+      from:    CodeMirror.Pos(loc.first_line - 1, loc.first_column),
+      to:      CodeMirror.Pos(loc.last_line  - 1, loc.last_column),
+      message: str
+    });
+  };
+
+  try {
+    jsonlint.parse(text);
+  }
+  catch(e) {
+    // Do nothing we catch the error above
+  }
+  return found;
+});
+
 CodeMirror.registerHelper("lint", "mgl", function(text, opts, doc) {
   const found = [];
   const {parser} = jsonlint;


### PR DESCRIPTION
The `<SourceTypeEditor/>` was using the `mapbox-gl-style-spec` bring back `jsonlint`.

Demo <https://2539-84182601-gh.circle-artifacts.com/0/artifacts/build/index.html>

Fixes #660