### PR TITLE
Added tip to JSON editor about how to unfocus

### DIFF
--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -159,7 +159,7 @@ class JSONEditor extends React.Component {
       style.maxHeight = this.props.maxHeight;
     }
 
-    return <div className="JSONEditor" onPointerDown={this.onPointerDown}>
+    return <div className="JSONEditor" onPointerDown={this.onPointerDown} aria-hidden="true">
       <div class={classnames("JSONEditor__message", {"JSONEditor__message--on": showMessage})}>
         Press <kbd>ESC</kbd> to lose focus
       </div>

--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -161,7 +161,7 @@ class JSONEditor extends React.Component {
     }
 
     return <div className="JSONEditor" onPointerDown={this.onPointerDown} aria-hidden="true">
-      <div class={classnames("JSONEditor__message", {"JSONEditor__message--on": showMessage})}>
+      <div className={classnames("JSONEditor__message", {"JSONEditor__message--on": showMessage})}>
         Press <kbd>ESC</kbd> to lose focus
       </div>
       <div

--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -54,6 +54,7 @@ class JSONEditor extends React.Component {
     super(props)
     this.state = {
       isEditing: false,
+      showMessage: false,
       prevValue: this.props.getValue(this.props.layer),
     };
   }
@@ -82,17 +83,24 @@ class JSONEditor extends React.Component {
     this._doc.on('blur', this.onBlur);
   }
 
-  onFocus = () => {
+  onPointerDown = (cm, e) => {
+    this._keyEvent = "pointer";
+  }
+
+  onFocus = (cm, e) => {
     this.props.onFocus();
     this.setState({
-      isEditing: true
+      isEditing: true,
+      showMessage: (this._keyEvent === "keyboard"),
     });
   }
 
   onBlur = () => {
+    this._keyEvent = "keyboard";
     this.props.onBlur();
     this.setState({
-      isEditing: false
+      isEditing: false,
+      showMessage: false,
     });
   }
 
@@ -145,16 +153,22 @@ class JSONEditor extends React.Component {
   }
 
   render() {
+    const {showMessage} = this.state;
     const style = {};
     if (this.props.maxHeight) {
       style.maxHeight = this.props.maxHeight;
     }
 
-    return <div
-      className={classnames("codemirror-container", this.props.className)}
-      ref={(el) => this._el = el}
-      style={style}
-    />
+    return <div className="JSONEditor" onPointerDown={this.onPointerDown}>
+      <div class={classnames("JSONEditor__message", {"JSONEditor__message--on": showMessage})}>
+        Press <kbd>ESC</kbd> to lose focus
+      </div>
+      <div
+        className={classnames("codemirror-container", this.props.className)}
+        ref={(el) => this._el = el}
+        style={style}
+      />
+    </div>
   }
 }
 

--- a/src/components/layers/JSONEditor.jsx
+++ b/src/components/layers/JSONEditor.jsx
@@ -51,7 +51,8 @@ class JSONEditor extends React.Component {
   }
 
   constructor(props) {
-    super(props)
+    super(props);
+    this._keyEvent = "keyboard";
     this.state = {
       isEditing: false,
       showMessage: false,

--- a/src/styles/_codemirror.scss
+++ b/src/styles/_codemirror.scss
@@ -62,3 +62,37 @@
   background-color: #bb0000;
   color: white !important;
 }
+
+@keyframes JSONEditor__animation-fade {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  } 
+}
+
+.JSONEditor__message {
+  position: absolute;
+  right: 0;
+  font-size: 0.85em;
+  z-index: 99999;
+  padding: 0.3em 0.5em;
+  background: hsla(0, 0%, 0%, 0.3);
+  color: $color-lowgray;
+  border-bottom-left-radius: 2px;
+  transition: opacity 320ms ease;
+  opacity: 0;
+  pointer-events: none;
+
+  &--on {
+    opacity: 1;
+    animation: 320ms ease 0s JSONEditor__animation-fade;
+    animation-delay: 2000ms;
+    animation-fill-mode: forwards;
+  }
+
+  kbd {
+    font-family: monospace;
+  }
+}


### PR DESCRIPTION
The JSON editor now displays a helper message for a couple of seconds if you keyboard tab to it.

> Press `ESC` to lose focus

This is _only_ present when focusing via keyboard (tab) and not mouse 

<img width="372" alt="Screenshot 2020-05-21 at 09 13 16" src="https://user-images.githubusercontent.com/235915/82541635-b1227f00-9b48-11ea-8dae-760e40f2b20d.png">

Related to #322