### PR TITLE
Fixed README styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # Maputnik
 
-[![GitHub CI status](https://github.com/maputnik/editor/workflows/ci/badge.svg)][github-action-ci]
-[![Dependency Status](https://david-dm.org/maputnik/editor.svg)][dm-prod]
-[![Dev Dependency Status](https://david-dm.org/maputnik/editor/dev-status.svg)][dm-dev]
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)][license]
-
-[github-action-ci]: https://github.com/maputnik/editor/actions?query=workflow%3Aci
-[dm-prod]:          https://david-dm.org/maputnik/editor
-[dm-dev]:           https://david-dm.org/maputnik/editor?type=dev
-[license]:          https://tldrlegal.com/license/mit-license
-
-<img width="200" align="right" alt="Maputnik" src="https://cdn.jsdelivr.net/gh/maputnik/editor@1.5.0/src/img/maputnik.png" />
+<img width="200" alt="Maputnik" src="https://cdn.jsdelivr.net/gh/maputnik/design/logos/logo-color.png" />
 
 A free and open visual editor for the [Mapbox GL styles](https://www.mapbox.com/mapbox-gl-style-spec/)
 targeted at developers and map designers.
+
+[![GitHub CI status](https://github.com/maputnik/editor/workflows/ci/badge.svg)][github-action-ci]
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)][license]
+
+[github-action-ci]: https://github.com/maputnik/editor/actions?query=workflow%3Aci
+[license]:          https://tldrlegal.com/license/mit-license
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
+<img width="200" alt="Maputnik logo" src="https://cdn.jsdelivr.net/gh/maputnik/design/logos/logo-color.png" />
+
 # Maputnik
-
-<img width="200" alt="Maputnik" src="https://cdn.jsdelivr.net/gh/maputnik/design/logos/logo-color.png" />
-
-A free and open visual editor for the [Mapbox GL styles](https://www.mapbox.com/mapbox-gl-style-spec/)
-targeted at developers and map designers.
-
 [![GitHub CI status](https://github.com/maputnik/editor/workflows/ci/badge.svg)][github-action-ci]
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)][license]
 
 [github-action-ci]: https://github.com/maputnik/editor/actions?query=workflow%3Aci
 [license]:          https://tldrlegal.com/license/mit-license
+
+A free and open visual editor for the [Mapbox GL styles](https://www.mapbox.com/mapbox-gl-style-spec/)
+targeted at developers and map designers.
 
 
 ## Usage


### PR DESCRIPTION
Fixes

 - Updated logo to point to maputnik/design
 - Removed broken dependency badges
 - Stop aligning logo right because it looked bad on mobile

_Before_
<img width="349" alt="Screenshot of README.md before changes" src="https://user-images.githubusercontent.com/235915/83003576-6a300000-a006-11ea-89c4-0cb8649a2fad.png">

_After_
<img width="352" alt="Screenshot of README.md after changes" src="https://user-images.githubusercontent.com/235915/83003589-6e5c1d80-a006-11ea-91a9-b25c139fffca.png">
