### PR TITLE
Add again shouldComponentUpdate

### DIFF
--- a/src/components/MapMapboxGl.jsx
+++ b/src/components/MapMapboxGl.jsx
@@ -97,6 +97,16 @@ export default class MapMapboxGl extends React.Component {
     )
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    let should = false;
+    try {
+      should = JSON.stringify(this.props) !== JSON.stringify(nextProps) || JSON.stringify(this.state) !== JSON.stringify(nextState);
+    } catch(e) {
+      // no biggie, carry on
+    }
+    return should;
+  }
+
   componentDidUpdate(prevProps) {
     if(!IS_SUPPORTED) return;
 


### PR DESCRIPTION
Fixes the regression reported in #674 by reverting https://github.com/maputnik/editor/commit/f3b8c5362ad40c4fe4c2517f47c7879d8d8a6093

Without `shouldComponentUpdate` the style provided in https://github.com/maputnik/editor/issues/674#issuecomment-623491287 isn't working. 

`shouldComponentUpdate` was removed for performance reasons (https://github.com/maputnik/editor/pull/571). We could look into the performance issue later, but for know I think it's better to fix this regression for the upcoming `v1.8.0` release. 

