### PR TITLE
Update Basic and Toner styles

### DIFF
--- a/src/config/styles.json
+++ b/src/config/styles.json
@@ -6,8 +6,8 @@
     "thumbnail": "https://maputnik.github.io/thumbnails/osm-liberty.png"
   },
   {
-    "id": "klokantech-basic",
-    "title": "Klokantech Basic",
+    "id": "maptiler-basic-gl-style",
+    "title": "Maptiler Basic",
     "url": "https://cdn.jsdelivr.net/gh/openmaptiles/klokantech-basic-gl-style@v1.9/style.json",
     "thumbnail": "https://maputnik.github.io/thumbnails/klokantech-basic.png"
   },
@@ -30,9 +30,9 @@
     "thumbnail": "https://maputnik.github.io/thumbnails/osm-bright.png"
   },
   {
-    "id": "toner-gl-style",
+    "id": "maptiler-toner-gl-style",
     "title": "Toner",
-    "url": "https://cdn.jsdelivr.net/gh/openmaptiles/toner-gl-style@dcb6e64/style.json",
+    "url": "https://cdn.jsdelivr.net/gh/openmaptiles/toner-gl-style@339e5b7/style.json",
     "thumbnail": "https://maputnik.github.io/thumbnails/toner.png"
   },
   {


### PR DESCRIPTION
The repos were renamed
https://github.com/openmaptiles/maptiler-basic-gl-style
https://github.com/openmaptiles/maptiler-toner-gl-style
and for _Toner_ there were also changes to the license and style.