### PR TITLE
Add new query params to allow better control of ApiStyleStore

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -95,14 +95,19 @@ export default class App extends React.Component {
 
     this.revisionStore = new RevisionStore()
     const params = new URLSearchParams(window.location.search.substring(1))
-    let port = params.get("localport")
+    // `localport` param is a legacy undocumented feature. Possibly deprecate this in future if not required?
+    let port = params.get("localport") || params.get("styleApiPort")
     if (port == null && (window.location.port != 80 && window.location.port != 443)) {
       port = window.location.port
     }
     this.styleStore = new ApiStyleStore({
       onLocalStyleChange: mapStyle => this.onStyleChanged(mapStyle, {save: false}),
       port: port,
-      host: params.get("localhost")
+      // `localhost` param is a legacy undocumented feature. Possibly deprecate this in future if not required?
+      host: params.get("localhost") || params.get("styleApiHost"),
+      protocol: params.get("styleApiProtocol"),
+      path: params.get("styleApiPath"),
+      preselectedId: params.get("styleApiPreselectedId"),
     })
 
 

--- a/src/libs/apistore.js
+++ b/src/libs/apistore.js
@@ -8,13 +8,20 @@ export class ApiStyleStore {
     this.onLocalStyleChange = opts.onLocalStyleChange || (() => {})
     const port = opts.port || '8000'
     const host = opts.host || 'localhost'
-    this.localUrl = `http://${host}:${port}`
+    const path = opts.path || '/style'
+    const protocol = opts.protocol || 'http'
+    this.apiUrl = `${protocol}://${host}:${port}${path}`
     this.websocketUrl = `ws://${host}:${port}/ws`
+    this.latestStyleId = opts.preselectedId
     this.init = this.init.bind(this)
   }
 
   init(cb) {
-    fetch(this.localUrl + '/styles', {
+    if (this.latestStyleId) {
+      this.notifyLocalChanges()
+      return cb(null)
+    }
+    fetch(this.apiUrl, {
       mode: 'cors',
     })
     .then((response) =>  {
@@ -49,7 +56,7 @@ export class ApiStyleStore {
 
   latestStyle(cb) {
     if(this.latestStyleId) {
-      fetch(this.localUrl + '/styles/' + this.latestStyleId, {
+      fetch(`${this.apiUrl}/${this.latestStyleId}`, {
         mode: 'cors',
       })
       .then(function(response) {
@@ -71,8 +78,7 @@ export class ApiStyleStore {
       )
     );
 
-    const id = mapStyle.id
-    fetch(this.localUrl + '/styles/' + id, {
+    fetch(`${this.apiUrl}/${mapStyle.id}`, {
       method: "PUT",
       mode: 'cors',
       headers: {


### PR DESCRIPTION
I'm currently trying to integrate Maputnik into our platform and haven't been able to find a viable way to allow a non-technical map designer to work on a number of different styles without the need for a technical user level install or an offline, communication based process.

With these proposed changes, a link can be given to a non-technical map designer which allows them to modify a given map design which exists on a standard REST API endpoint that they would require access to.

This method also allows the decoupling of the CLI tool from the front-end which makes integrating the tool easier in more contexts as well. i.e. Services with Kubernetes.

By passing through the query params of `styleApiProtocol`, `styleApiHost`, `styleApiPort` and `styleApiPath` Maputnik can then access any REST API endpoint to get styles. At the moment, ApiStyleStore selects the first available style id, so I have also added the param `styleApiPreselectedId` which allows for the specific selection of style where more than one exist.

As an example:
```
https://maputnik.github.io/?styleApiProtocol=https&styleApiHost=example.com&styleApiPort=80&styleApiPath=%2Fapi%2Fstyles&styleApiPreselectedId=xxxyyyzzz
```

The above link will allow the editing of the style at https://example.com/api/styles/xxxyyyzzz as long as the endpoint implements typical REST measures.

Thought I'd put this forward to gather feedback before doing any further work. Any pointers with how this might be tested in the current suite would be great as well as how and where I should document this feature.