### PR TITLE
Fix to not change layer key while editing layer

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -772,7 +772,10 @@ export default class App extends React.Component {
           }
         }
         if (!invalid) {
-          this.setState({selectedLayerIndex});
+          this.setState({
+            selectedLayerIndex,
+            selectedLayerOriginalId: this.state.mapStyle.layers[selectedLayerIndex].id,
+          });
         }
       }
       catch (err) {
@@ -782,7 +785,10 @@ export default class App extends React.Component {
   }
 
   onLayerSelect = (index) => {
-    this.setState({ selectedLayerIndex: index }, this.setStateInUrl);
+    this.setState({
+      selectedLayerIndex: index,
+      selectedLayerOriginalId: this.state.mapStyle.layers[index].id,
+    }, this.setStateInUrl);
   }
 
   setModal(modalName, value) {
@@ -851,7 +857,7 @@ export default class App extends React.Component {
     />
 
     const layerEditor = selectedLayer ? <LayerEditor
-      key={selectedLayer.id}
+      key={this.state.selectedLayerOriginalId}
       layer={selectedLayer}
       layerIndex={this.state.selectedLayerIndex}
       isFirstLayer={this.state.selectedLayerIndex < 1}

--- a/src/components/FieldId.jsx
+++ b/src/components/FieldId.jsx
@@ -20,7 +20,7 @@ export default class FieldId extends React.Component {
     >
       <InputString
         value={this.props.value}
-        onChange={this.props.onChange}
+        onInput={this.props.onChange}
       />
     </Block>
   }


### PR DESCRIPTION
Once we select a layer the components key remains until we select another layer, regardless of whether we edit the layer id in the editor. This fixes the `<LayerEditor/>` component recycling on layer `id` edit, which has the consequences described in #718 

Fixes #718