### PR TITLE
Use latest firefox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,8 +162,7 @@ jobs:
 
     services:
       selenium:
-        # geckodriver-0.31 seems to have problems as of 2022 May 1
-        image: selenium/standalone-${{ matrix.browser == 'firefox' && 'firefox:99.0-geckodriver-0.30-20220427' || matrix.browser }}
+        image: selenium/standalone-${{ matrix.browser }}
         ports:
         - 4444:4444
         options: --shm-size=2gb

--- a/config/wdio.conf.js
+++ b/config/wdio.conf.js
@@ -26,7 +26,7 @@ exports.config = {
     }
   ],
   // geckodriver-0.31 seems to have problems as of 2022 May 1
-  services: process.env.DOCKER_HOST ? [] : [ ['selenium-standalone', { drivers: { firefox: '0.30.0', chrome: 'latest' } } ] ],
+  services: process.env.DOCKER_HOST ? [] : [ ['selenium-standalone', { drivers: { firefox: 'latest', chrome: 'latest' } } ] ],
   logLevel: 'info',
   bail: 0,
   screenshotPath: SCREENSHOT_PATH,


### PR DESCRIPTION
Due to some issues with gecko 31, the version was fixed to gecko 30. Gecko is at 33 now, so we can again be on latest.