### PR TITLE
Fix duplicate layer rename error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add support to edit local files on the file system if supported by the browser
 - Upgrade to MapLibre LG JS v5
 - Upgrade Vite 6 and Cypress 14 ([#970](https://github.com/maplibre/maputnik/pull/970))
+- Show error when renaming a layer to an existing ID
 - Upgrade OpenLayers from v6 to v10
 - When loading a style into localStorage that causes a QuotaExceededError, purge localStorage and retry
 - Remove react-autobind dependency

--- a/cypress/e2e/layers.cy.ts
+++ b/cypress/e2e/layers.cy.ts
@@ -157,6 +157,18 @@ describe("layers", () => {
           });
         });
 
+        it("shows duplicate id error", () => {
+          const firstId = createBackground();
+          when.modal.open();
+          const secondId = when.modal.fillLayers({ type: "background" });
+          when.click("layer-list-item:" + secondId);
+          when.setValue("layer-editor.layer-id.input", "background:" + firstId);
+          when.click("min-zoom");
+          then(get.element(".maputnik-inline-error")).shouldContainText(
+            "Layer ID already exists"
+          );
+        });
+
         describe("min-zoom", () => {
           let bgId: string;
 

--- a/src/components/LayerEditor.tsx
+++ b/src/components/LayerEditor.tsx
@@ -135,6 +135,7 @@ class LayerEditorInternal extends React.Component<LayerEditorInternalProps, Laye
     if(this.props.layer.metadata) {
       comment = (this.props.layer.metadata as any)['maputnik:comment']
     }
+    const t = this.props.t;
     const {errors, layerIndex} = this.props;
 
     const errorData: {[key in LayerSpecification as string]: {message: string}} = {};
@@ -157,53 +158,57 @@ class LayerEditorInternal extends React.Component<LayerEditorInternalProps, Laye
     }
 
     switch(type) {
-    case 'layer': return <div>
-      <FieldId
-        value={this.props.layer.id}
-        wdKey="layer-editor.layer-id"
-        error={errorData.id}
-        onChange={newId => this.props.onLayerIdChange(this.props.layerIndex, this.props.layer.id, newId)}
-      />
-      <FieldType
-        disabled={true}
-        error={errorData.type}
-        value={this.props.layer.type}
-        onChange={newType => this.props.onLayerChanged(
-          this.props.layerIndex,
-          changeType(this.props.layer, newType)
-        )}
-      />
-      {this.props.layer.type !== 'background' && <FieldSource
-        error={errorData.source}
-        sourceIds={Object.keys(this.props.sources!)}
-        value={this.props.layer.source}
-        onChange={v => this.changeProperty(null, 'source', v)}
-      />
-      }
-      {['background', 'raster', 'hillshade', 'heatmap'].indexOf(this.props.layer.type) < 0 &&
+    case 'layer': {
+      const duplicateId = errorData.id && /duplicate layer id/.test(errorData.id.message);
+      return <div>
+        <FieldId
+          value={this.props.layer.id}
+          wdKey="layer-editor.layer-id"
+          error={errorData.id}
+          onChange={newId => this.props.onLayerIdChange(this.props.layerIndex, this.props.layer.id, newId)}
+        />
+        {duplicateId && <div className="maputnik-inline-error">{t('Layer ID already exists')}</div>}
+        <FieldType
+          disabled={true}
+          error={errorData.type}
+          value={this.props.layer.type}
+          onChange={newType => this.props.onLayerChanged(
+            this.props.layerIndex,
+            changeType(this.props.layer, newType)
+          )}
+        />
+        {this.props.layer.type !== 'background' && <FieldSource
+          error={errorData.source}
+          sourceIds={Object.keys(this.props.sources!)}
+          value={this.props.layer.source}
+          onChange={v => this.changeProperty(null, 'source', v)}
+        />
+        }
+        {['background', 'raster', 'hillshade', 'heatmap'].indexOf(this.props.layer.type) < 0 &&
         <FieldSourceLayer
           error={errorData['source-layer']}
           sourceLayerIds={sourceLayerIds}
           value={(this.props.layer as any)['source-layer']}
           onChange={v => this.changeProperty(null, 'source-layer', v)}
         />
-      }
-      <FieldMinZoom
-        error={errorData.minzoom}
-        value={this.props.layer.minzoom}
-        onChange={v => this.changeProperty(null, 'minzoom', v)}
-      />
-      <FieldMaxZoom
-        error={errorData.maxzoom}
-        value={this.props.layer.maxzoom}
-        onChange={v => this.changeProperty(null, 'maxzoom', v)}
-      />
-      <FieldComment
-        error={errorData.comment}
-        value={comment}
-        onChange={v => this.changeProperty('metadata', 'maputnik:comment', v == ""  ? undefined : v)}
-      />
-    </div>
+        }
+        <FieldMinZoom
+          error={errorData.minzoom}
+          value={this.props.layer.minzoom}
+          onChange={v => this.changeProperty(null, 'minzoom', v)}
+        />
+        <FieldMaxZoom
+          error={errorData.maxzoom}
+          value={this.props.layer.maxzoom}
+          onChange={v => this.changeProperty(null, 'maxzoom', v)}
+        />
+        <FieldComment
+          error={errorData.comment}
+          value={comment}
+          onChange={v => this.changeProperty('metadata', 'maputnik:comment', v == ""  ? undefined : v)}
+        />
+      </div>
+    }
     case 'filter': return <div>
       <div className="maputnik-filter-editor-wrapper">
         <FilterEditor


### PR DESCRIPTION
## Summary
<img width="362" alt="image" src="https://github.com/user-attachments/assets/1f0e85f0-da92-4fdd-bc22-919aa646b42f" />

- warn when changing layer ID to duplicate
- test duplicate layer rename error
- document the change in the changelog

## Testing
- `npm run lint`
- `npm run build`
- `xvfb-run -a npm run test` *(fails: Cypress couldn't verify that server is running)*

------
https://chatgpt.com/codex/tasks/task_e_686907f11134833184ffde804d8b364d