### PR TITLE
Fix editor replace behavior

### DIFF
--- a/src/components/InputJson.tsx
+++ b/src/components/InputJson.tsx
@@ -74,12 +74,15 @@ class InputJsonInternal extends React.Component<InputJsonInternalProps, InputJso
   componentDidUpdate(prevProps: InputJsonProps) {
     if (!this.state.isEditing && prevProps.value !== this.props.value) {
       this._cancelNextChange = true;
+      const currentSelection = this._view!.state.selection;
       this._view!.dispatch({
         changes: {
           from: 0,
           to: this._view!.state.doc.length,
           insert: this.getPrettyJson(this.props.value)
-        }
+        },
+        selection: currentSelection,
+        scrollIntoView: true
       });
     }
   }


### PR DESCRIPTION
## Launch Checklist

- Fixes #1492

This adds the relevant selection and scroll intoview parameters that were previously missing as part of the migration to code mirror 6.
It fixes the replace part as described in the bug.

 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.

While I think tests are needed here, I'm not sure there's an easy way to actually test this because testing the code mirror editor is hard, and even harder when there's key pressing (ctrl +F on windows and meta + F on mac) involved...