### PR TITLE
fix root relative paths

### DIFF
--- a/src/components/MapMaplibreGl.tsx
+++ b/src/components/MapMaplibreGl.tsx
@@ -143,7 +143,7 @@ class MapMaplibreGlInternal extends React.Component<MapMaplibreGlInternalProps, 
       // not support this for everything:
       // https://github.com/maplibre/maplibre-gl-js/issues/6818
       transformRequest: (url) => {
-        if (url.startsWith('/')) {
+        if (url.startsWith("/")) {
           url = `${window.location.origin}${url}`;
         }
         return { url };


### PR DESCRIPTION
## Launch Checklist

this is a follow up to https://github.com/maplibre/maputnik/pull/1549

when testing this, I only used raster tiles. However root relative vector tiles are not loaded correctly by maplibre gl js: https://github.com/maplibre/maplibre-gl-js/issues/6818

The current state is problematic as with https://github.com/maplibre/maputnik/pull/1549 we don't have the visuals that the url is wrong.

Till [the maplibre issue](https://github.com/maplibre/maplibre-gl-js/issues/6818) is fixed (if it even need to be fixed), we can make use of [transformRequest](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/#transformrequest) where we convert root relative requests to "real" requests

 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes -> in maplibre ticket
