### PR TITLE
fix: resolve layer click selection conflict with dnd-kit drag listeners

### DIFF
--- a/src/components/LayerListItem.tsx
+++ b/src/components/LayerListItem.tsx
@@ -13,11 +13,19 @@ type DraggableLabelProps = {
   layerType: string
   dragAttributes?: React.HTMLAttributes<HTMLElement>
   dragListeners?: React.HTMLAttributes<HTMLElement>
+  onSelect?: () => void
 };
 
 const DraggableLabel: React.FC<DraggableLabelProps> = (props) => {
   const {dragAttributes, dragListeners} = props;
-  return <div className="maputnik-layer-list-item-handle" {...dragAttributes} {...dragListeners}>
+
+  const handleClick = (e: React.MouseEvent) => {
+    // Ensure layer selection fires even when dnd-kit captures the pointer
+    e.stopPropagation();
+    props.onSelect?.();
+  };
+
+  return <div className="maputnik-layer-list-item-handle" {...dragAttributes} {...dragListeners} onClick={handleClick}>
     <IconLayer
       className="layer-handle__icon"
       type={props.layerType}
@@ -137,6 +145,7 @@ const LayerListItem = React.forwardRef<HTMLLIElement, LayerListItemProps>((props
         layerType={props.layerType}
         dragAttributes={attributes}
         dragListeners={listeners}
+        onSelect={() => props.onLayerSelect(props.layerIndex)}
       />
       <span style={{flexGrow: 1}} />
       <IconAction


### PR DESCRIPTION
## Summary

Fixes an issue where clicking on layer names in the layer list doesn't reliably open the layer properties editor.

## Problem

The `DraggableLabel` component in `LayerListItem.tsx` spreads dnd-kit's `dragListeners` (which include `onPointerDown`) onto the layer name handle div. This pointer capture can intercept normal click events, preventing the parent `<li>`'s `onClick` handler from firing. The result is that clicking a layer name sometimes fails to select and display its properties.

## Solution

Added an explicit `onClick` handler to the `DraggableLabel` component that:
1. Calls `e.stopPropagation()` to prevent event bubbling conflicts
2. Directly invokes the `onSelect` callback passed from the parent

The `onClick` is spread **after** `dragListeners`, ensuring it takes precedence. This approach preserves full drag-and-drop functionality while guaranteeing click selection always works.

## Changes

- **`src/components/LayerListItem.tsx`**: Added `onSelect` prop to `DraggableLabel`, implemented `handleClick` with `stopPropagation`, applied `onClick` after drag listeners on the handle div.