### PR TITLE
feat: add adjustable sidebar width with drag handle

### DIFF
--- a/cypress/e2e/sidebar-resize.cy.ts
+++ b/cypress/e2e/sidebar-resize.cy.ts
@@ -1,0 +1,30 @@
+import { MaputnikDriver } from "./maputnik-driver";
+
+describe("sidebar resize", () => {
+  const { beforeAndAfter, when } = new MaputnikDriver();
+  beforeAndAfter();
+
+  beforeEach(() => {
+    when.setStyle("both");
+  });
+
+  it("resize handle is visible", () => {
+    cy.get("[data-testid='sidebar-resize-handle']").should("exist").and("be.visible");
+  });
+
+  it("dragging the handle changes sidebar width", () => {
+    cy.get(".maputnik-layout-list").then(($list) => {
+      const initialWidth = $list[0].getBoundingClientRect().width;
+
+      cy.get("[data-testid='sidebar-resize-handle']")
+        .realMouseDown({ position: "center" })
+        .realMouseMove(100, 0, { position: "center" })
+        .realMouseUp();
+
+      cy.get(".maputnik-layout-list").should(($listAfter) => {
+        const newWidth = $listAfter[0].getBoundingClientRect().width;
+        expect(newWidth).to.be.greaterThan(initialWidth);
+      });
+    });
+  });
+});

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,9 +1,16 @@
-import React from "react";
+import React, {useCallback, useEffect, useRef, useState} from "react";
 import ScrollContainer from "./ScrollContainer";
-import { type WithTranslation, withTranslation } from "react-i18next";
-import { IconContext } from "react-icons";
+import {useTranslation} from "react-i18next";
+import {IconContext} from "react-icons";
+import {
+  DEFAULT_LIST_WIDTH,
+  DEFAULT_SIDEBAR_WIDTH,
+  clampSidebarWidth,
+  getSavedSidebarWidth,
+  saveSidebarWidth,
+} from "../libs/sidebar";
 
-type AppLayoutInternalProps = {
+type AppLayoutProps = {
   toolbar: React.ReactElement
   layerList: React.ReactElement
   layerEditor?: React.ReactElement
@@ -11,44 +18,109 @@ type AppLayoutInternalProps = {
   map: React.ReactElement
   bottom?: React.ReactElement
   modals?: React.ReactNode
-} & WithTranslation;
+};
 
-class AppLayoutInternal extends React.Component<AppLayoutInternalProps> {
+export default function AppLayout(props: AppLayoutProps) {
+  const {i18n} = useTranslation();
 
-  render() {
-    document.body.dir = this.props.i18n.dir();
+  useEffect(() => {
+    document.body.dir = i18n.dir();
+  }, [i18n]);
 
-    return <IconContext.Provider value={{size: "14px"}}>
-      <div className="maputnik-layout">
-        {this.props.toolbar}
-        <div className="maputnik-layout-main">
-          {this.props.codeEditor && <div className="maputnik-layout-code-editor">
-            <ScrollContainer>
-              {this.props.codeEditor}
-            </ScrollContainer>
-          </div>
-          }
-          {!this.props.codeEditor && <>
-            <div className="maputnik-layout-list">
-              {this.props.layerList}
-            </div>
-            <div className="maputnik-layout-drawer">
-              <ScrollContainer>
-                {this.props.layerEditor}
-              </ScrollContainer>
-            </div>
-          </>}
-          {this.props.map}
-        </div>
-        {this.props.bottom && <div className="maputnik-layout-bottom">
-          {this.props.bottom}
+  const [sidebarWidth, setSidebarWidth] = useState<number>(
+    () => getSavedSidebarWidth() ?? DEFAULT_SIDEBAR_WIDTH
+  );
+  const isDragging = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(0);
+
+  // Compute proportional sub-widths so list and drawer scale together
+  const listRatio = DEFAULT_LIST_WIDTH / DEFAULT_SIDEBAR_WIDTH;
+  const listWidth = Math.round(sidebarWidth * listRatio);
+  const drawerWidth = sidebarWidth - listWidth;
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    startX.current = e.clientX;
+    startWidth.current = sidebarWidth;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, [sidebarWidth]);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      const isRtl = document.body.dir === "rtl";
+      const delta = isRtl
+        ? startX.current - e.clientX
+        : e.clientX - startX.current;
+      const newWidth = clampSidebarWidth(startWidth.current + delta);
+      setSidebarWidth(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      if (isDragging.current) {
+        isDragging.current = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        // Save on release
+        setSidebarWidth((w) => {
+          saveSidebarWidth(w);
+          return w;
+        });
+      }
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  const layoutStyle = {
+    "--sidebar-list-width": `${listWidth}px`,
+    "--sidebar-drawer-width": `${drawerWidth}px`,
+    "--sidebar-total-width": `${sidebarWidth}px`,
+  } as React.CSSProperties;
+
+  return <IconContext.Provider value={{size: "14px"}}>
+    <div className="maputnik-layout" style={layoutStyle}>
+      {props.toolbar}
+      <div className="maputnik-layout-main">
+        {props.codeEditor && <div className="maputnik-layout-code-editor">
+          <ScrollContainer>
+            {props.codeEditor}
+          </ScrollContainer>
         </div>
         }
-        {this.props.modals}
+        {!props.codeEditor && <>
+          <div className="maputnik-layout-list">
+            {props.layerList}
+          </div>
+          <div className="maputnik-layout-drawer">
+            <ScrollContainer>
+              {props.layerEditor}
+            </ScrollContainer>
+          </div>
+          <div
+            className="maputnik-layout-resize-handle"
+            data-testid="sidebar-resize-handle"
+            onMouseDown={handleMouseDown}
+            title="Drag to resize sidebar"
+            tabIndex={-1}
+            aria-hidden="true"
+          />
+        </>}
+        {props.map}
       </div>
-    </IconContext.Provider>;
-  }
+      {props.bottom && <div className="maputnik-layout-bottom">
+        {props.bottom}
+      </div>
+      }
+      {props.modals}
+    </div>
+  </IconContext.Provider>;
 }
-
-const AppLayout = withTranslation()(AppLayoutInternal);
-export default AppLayout;

--- a/src/libs/sidebar.test.ts
+++ b/src/libs/sidebar.test.ts
@@ -1,0 +1,80 @@
+import {describe, it, expect, beforeEach, vi} from "vitest";
+import {
+  clampSidebarWidth,
+  getSavedSidebarWidth,
+  saveSidebarWidth,
+  MIN_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  DEFAULT_SIDEBAR_WIDTH,
+} from "./sidebar";
+
+describe("sidebar helpers", () => {
+  describe("clampSidebarWidth", () => {
+    it("returns MIN when value is below minimum", () => {
+      expect(clampSidebarWidth(100)).toBe(MIN_SIDEBAR_WIDTH);
+    });
+
+    it("returns MAX when value exceeds maximum", () => {
+      expect(clampSidebarWidth(1200)).toBe(MAX_SIDEBAR_WIDTH);
+    });
+
+    it("returns the value when within range", () => {
+      expect(clampSidebarWidth(500)).toBe(500);
+    });
+
+    it("returns exactly MIN at boundary", () => {
+      expect(clampSidebarWidth(MIN_SIDEBAR_WIDTH)).toBe(MIN_SIDEBAR_WIDTH);
+    });
+
+    it("returns exactly MAX at boundary", () => {
+      expect(clampSidebarWidth(MAX_SIDEBAR_WIDTH)).toBe(MAX_SIDEBAR_WIDTH);
+    });
+  });
+
+  describe("getSavedSidebarWidth", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("returns null when nothing is stored", () => {
+      expect(getSavedSidebarWidth()).toBeNull();
+    });
+
+    it("returns the stored width when valid", () => {
+      localStorage.setItem("maputnik:sidebarWidth", "600");
+      expect(getSavedSidebarWidth()).toBe(600);
+    });
+
+    it("returns null when stored value is below MIN", () => {
+      localStorage.setItem("maputnik:sidebarWidth", "100");
+      expect(getSavedSidebarWidth()).toBeNull();
+    });
+
+    it("returns null when stored value is above MAX", () => {
+      localStorage.setItem("maputnik:sidebarWidth", "9999");
+      expect(getSavedSidebarWidth()).toBeNull();
+    });
+
+    it("returns null when stored value is not a number", () => {
+      localStorage.setItem("maputnik:sidebarWidth", "abc");
+      expect(getSavedSidebarWidth()).toBeNull();
+    });
+  });
+
+  describe("saveSidebarWidth", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("persists the width to localStorage", () => {
+      saveSidebarWidth(500);
+      expect(localStorage.getItem("maputnik:sidebarWidth")).toBe("500");
+    });
+  });
+
+  describe("DEFAULT_SIDEBAR_WIDTH", () => {
+    it("is the sum of list and drawer widths", () => {
+      expect(DEFAULT_SIDEBAR_WIDTH).toBe(570);
+    });
+  });
+});

--- a/src/libs/sidebar.ts
+++ b/src/libs/sidebar.ts
@@ -1,0 +1,44 @@
+/**
+ * Sidebar resize helpers.
+ *
+ * Extracted from AppLayout so they can be tested independently and
+ * reused if needed elsewhere.
+ */
+
+export const DEFAULT_LIST_WIDTH = 200;
+export const DEFAULT_DRAWER_WIDTH = 370;
+export const DEFAULT_SIDEBAR_WIDTH = DEFAULT_LIST_WIDTH + DEFAULT_DRAWER_WIDTH;
+export const MIN_SIDEBAR_WIDTH = 280;
+export const MAX_SIDEBAR_WIDTH = 800;
+
+const STORAGE_KEY = "maputnik:sidebarWidth";
+
+/** Read the persisted sidebar width from localStorage (if valid). */
+export function getSavedSidebarWidth(): number | null {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const val = parseInt(saved, 10);
+      if (!isNaN(val) && val >= MIN_SIDEBAR_WIDTH && val <= MAX_SIDEBAR_WIDTH) {
+        return val;
+      }
+    }
+  } catch {
+    // localStorage may be unavailable
+  }
+  return null;
+}
+
+/** Persist the sidebar width to localStorage. */
+export function saveSidebarWidth(width: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(width));
+  } catch {
+    // ignore
+  }
+}
+
+/** Clamp a width value to the allowed sidebar range. */
+export function clampSidebarWidth(width: number): number {
+  return Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, width));
+}

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -6,7 +6,8 @@
 .maputnik-map__container {
   background: white;
   display: flex;
-  width: vars.$layout-map-width;
+  flex: 1;
+  min-width: 0;
 
   &--error {
     align-items: center;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -13,6 +13,11 @@
 
 //APP LAYOUT
 .maputnik-layout {
+  // Default CSS custom properties (overridden inline by AppLayout component)
+  --sidebar-list-width: #{vars.$layout-list-width};
+  --sidebar-drawer-width: #{vars.$layout-editor-width};
+  --sidebar-total-width: #{vars.$layout-list-width + vars.$layout-editor-width};
+
   font-family: vars.$font-family;
   color: vars.$color-white;
 
@@ -29,19 +34,59 @@
   }
 
   &-list {
-    width: 200px;
+    width: var(--sidebar-list-width);
+    min-width: 0;
+    flex-shrink: 0;
     background-color: vars.$color-black;
   }
 
   &-drawer {
-    width: 370px;
+    width: var(--sidebar-drawer-width);
+    min-width: 0;
+    flex-shrink: 0;
     background-color: vars.$color-black;
     // scroll-container is position: absolute
     position: relative;
   }
 
+  &-resize-handle {
+    width: 5px;
+    flex-shrink: 0;
+    cursor: col-resize;
+    background-color: transparent;
+    position: relative;
+    z-index: 5;
+    transition: background-color 0.15s ease;
+
+    &:hover,
+    &:active {
+      background-color: rgba(vars.$color-lowgray, 0.5);
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 3px;
+      height: 30px;
+      border-radius: 2px;
+      background-color: vars.$color-lowgray;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+    }
+
+    &:hover::after,
+    &:active::after {
+      opacity: 0.7;
+    }
+  }
+
   &-code-editor {
-    width: 570px;
+    width: var(--sidebar-total-width);
+    min-width: 0;
+    flex-shrink: 0;
     background-color: vars.$color-black;
     // scroll-container is position: absolute
     position: relative;
@@ -52,7 +97,7 @@
     bottom: 0;
     right: 0;
     z-index: 10;
-    width: vars.$layout-map-width;
+    width: calc(100% - var(--sidebar-total-width));
     background-color: vars.$color-black;
   }
 }


### PR DESCRIPTION
## Summary
Adds a draggable resize handle to the sidebar, allowing users to adjust the sidebar width by dragging. The width is persisted to localStorage.

## Changes
- Convert AppLayout from class to functional component
- Add draggable resize handle (5px grip) between sidebar and map
- Use CSS custom properties for dynamic sidebar width
- Persist sidebar width to localStorage (key: `maputnik:sidebarWidth`)
- Extract sidebar helpers to `src/libs/sidebar.ts`
- Add unit tests for sidebar helpers (`src/libs/sidebar.test.ts`)
- Add Cypress e2e test for resize handle (`cypress/e2e/sidebar-resize.cy.ts`)

## Demo
https://github.com/user-attachments/assets/9ecd0476-61f6-41e8-b9f9-18e1e0b3f2bf

Closes #1677 review feedback from @HarelM:
- [x] Moved helpers to lib file
- [x] Removed double-click to reset
- [x] Added unit + e2e tests
- [x] Demo video

Note: The 9 CI e2e failures are all `Failed to initialize WebGL`  a Chrome 145 headless GPU issue on the GitHub Actions runner, not related to this PR. Every spec fails identically in the `before each` hook when MapLibre GL creates the map.