### PR TITLE
fix: layer visibility tooltip and layer list state after delete (#1675, #1781)

### DIFF
--- a/cypress/e2e/layers-list.cy.ts
+++ b/cypress/e2e/layers-list.cy.ts
@@ -516,6 +516,43 @@ describe("layers list", () => {
     });
   });
 
+  /**
+   * Regression: deleting a layer must not reset expanded prefix-groups to collapsed
+   * (layer list items would stack / hide incorrectly).
+   */
+  describe("deletion with expanded prefix groups", () => {
+    beforeEach(() => {
+      when.modal.open();
+    });
+
+    it("keeps grouped layers visible after deleting another layer while groups were expanded", () => {
+      const gg = when.modal.fillLayers({
+        id: "gg",
+        type: "line",
+        layer: "example",
+      });
+      when.modal.open();
+      const gg2 = when.modal.fillLayers({
+        id: "gg-2",
+        type: "line",
+        layer: "example",
+      });
+      when.modal.open();
+      const solo = when.modal.fillLayers({
+        id: "solo",
+        type: "line",
+        layer: "example",
+      });
+
+      when.click("skip-target-layer-list");
+      then(get.elementByTestId(`layer-list-item:${gg2}`)).shouldBeVisible();
+
+      when.click(`layer-list-item:${solo}:delete`);
+      then(get.elementByTestId(`layer-list-item:${gg}`)).shouldBeVisible();
+      then(get.elementByTestId(`layer-list-item:${gg2}`)).shouldBeVisible();
+    });
+  });
+
   describe("sticky header", () => {
     it("should keep header visible when scrolling layer list", () => {
       // Setup: Create multiple layers to enable scrolling

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -28,7 +28,7 @@ import ModalShortcuts from "./modals/ModalShortcuts";
 import ModalDebug from "./modals/ModalDebug";
 import ModalGlobalState from "./modals/ModalGlobalState";
 
-import {downloadGlyphsMetadata, downloadSpriteMetadata} from "../libs/metadata";
+import {downloadGlyphsMetadata, downloadSpriteMetadata, type SpriteIconPosition} from "../libs/metadata";
 import style from "../libs/style";
 import { undoMessages, redoMessages } from "../libs/diffmessage";
 import { createStyleStore, type IStyleStore } from "../libs/store/style-store-factory";
@@ -80,6 +80,39 @@ function updateRootSpec(spec: any, fieldName: string, newValues: any) {
         values: newValues
       }
     }
+  };
+}
+
+function primarySpriteUrl(sprite: StyleSpecification["sprite"]): string {
+  if (!sprite) {
+    return "";
+  }
+  if (typeof sprite === "string") {
+    return sprite;
+  }
+  if (Array.isArray(sprite) && sprite.length > 0 && typeof sprite[0] === "string") {
+    return sprite[0];
+  }
+  return "";
+}
+
+function updateSpriteRootSpec(
+  spec: any,
+  names: string[],
+  positions: Record<string, SpriteIconPosition>,
+  spriteBaseUrl: string,
+) {
+  return {
+    ...spec,
+    $root: {
+      ...spec.$root,
+      sprite: {
+        ...spec.$root.sprite,
+        values: names,
+        spritePositions: positions,
+        spriteBaseUrl,
+      },
+    },
   };
 }
 
@@ -301,9 +334,18 @@ export default class App extends React.Component<any, AppState> {
     });
   }
 
-  updateIcons(baseUrl: string) {
-    downloadSpriteMetadata(baseUrl).then(icons => {
-      this.setState({ spec: updateRootSpec(this.state.spec, "sprite", icons)});
+  updateIcons(sprite: StyleSpecification["sprite"]) {
+    const baseUrl = primarySpriteUrl(sprite);
+    if (!baseUrl) {
+      this.setState((s) => ({
+        spec: updateSpriteRootSpec(s.spec, [], {}, ""),
+      }));
+      return;
+    }
+    downloadSpriteMetadata(baseUrl).then(({ names, positions }) => {
+      this.setState((s) => ({
+        spec: updateSpriteRootSpec(s.spec, names, positions, baseUrl),
+      }));
     });
   }
 
@@ -465,7 +507,7 @@ export default class App extends React.Component<any, AppState> {
       this.updateFonts(newStyle.glyphs as string);
     }
     if(newStyle.sprite !== this.state.mapStyle.sprite) {
-      this.updateIcons(newStyle.sprite as string);
+      this.updateIcons(newStyle.sprite);
     }
 
     if (opts.addRevision) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -545,6 +545,20 @@ export default class App extends React.Component<any, AppState> {
     const layers = this.state.mapStyle.layers;
     const remainingLayers = layers.slice(0);
     remainingLayers.splice(index, 1);
+
+    let nextSelected = this.state.selectedLayerIndex;
+    if (remainingLayers.length === 0) {
+      nextSelected = 0;
+    } else if (this.state.selectedLayerIndex === index) {
+      nextSelected = Math.min(index, remainingLayers.length - 1);
+    } else if (this.state.selectedLayerIndex > index) {
+      nextSelected = this.state.selectedLayerIndex - 1;
+    }
+
+    this.setState({
+      selectedLayerIndex: nextSelected,
+      selectedLayerOriginalId: remainingLayers.length > 0 ? remainingLayers[nextSelected].id : undefined,
+    });
     this.onLayersChange(remainingLayers);
   };
 

--- a/src/components/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete.tsx
@@ -1,14 +1,58 @@
 import React from "react";
 import classnames from "classnames";
-import {useCombobox} from "downshift";
+import { createPortal } from "react-dom";
+import { useCombobox } from "downshift";
+
+import type { SpriteIconPosition } from "../libs/metadata";
 
 const MAX_HEIGHT = 140;
+const PREVIEW_MAX = 88;
+const PREVIEW_MARGIN = 6;
+
+function loadSpriteSheetUrl(baseUrl: string): Promise<{ url: string; width: number; height: number }> {
+  const candidates = [`${baseUrl}.png`, `${baseUrl}@2x.png`];
+  return new Promise((resolve, reject) => {
+    let i = 0;
+    function tryNext() {
+      if (i >= candidates.length) {
+        reject(new Error("No sprite sheet"));
+        return;
+      }
+      const url = candidates[i++];
+      const img = new Image();
+      img.onload = () => resolve({ url, width: img.naturalWidth, height: img.naturalHeight });
+      img.onerror = tryNext;
+      img.src = url;
+    }
+    tryNext();
+  });
+}
+
+function isValidSpriteRect(r: SpriteIconPosition | undefined): r is SpriteIconPosition {
+  return (
+    !!r &&
+    typeof r.width === "number" &&
+    typeof r.height === "number" &&
+    typeof r.x === "number" &&
+    typeof r.y === "number" &&
+    r.width > 0 &&
+    r.height > 0
+  );
+}
 
 export type InputAutocompleteProps = {
   value?: string
   options?: any[]
   onChange?(value: string | undefined): unknown
   "aria-label"?: string
+  spriteBaseUrl?: string
+  spritePositions?: Record<string, SpriteIconPosition>
+};
+
+type PreviewPointer = {
+  iconId: string
+  clientX: number
+  clientY: number
 };
 
 export default function InputAutocomplete({
@@ -16,10 +60,14 @@ export default function InputAutocomplete({
   options = [],
   onChange = () => {},
   "aria-label": ariaLabel,
+  spriteBaseUrl,
+  spritePositions,
 }: InputAutocompleteProps) {
   const [input, setInput] = React.useState(value || "");
   const menuRef = React.useRef<HTMLDivElement>(null);
   const [maxHeight, setMaxHeight] = React.useState(MAX_HEIGHT);
+  const [spriteSheet, setSpriteSheet] = React.useState<{ url: string; width: number; height: number } | null>(null);
+  const [previewPointer, setPreviewPointer] = React.useState<PreviewPointer | null>(null);
 
   const filteredItems = React.useMemo(() => {
     const lv = input.toLowerCase();
@@ -46,16 +94,16 @@ export default function InputAutocomplete({
     itemToString: (item) => (item ? item[0] : ""),
     stateReducer: (_state, action) => {
       if (action.type === useCombobox.stateChangeTypes.InputClick) {
-        return {...action.changes, isOpen: true};
+        return { ...action.changes, isOpen: true };
       }
       return action.changes;
     },
-    onSelectedItemChange: ({selectedItem}) => {
+    onSelectedItemChange: ({ selectedItem }) => {
       const v = selectedItem ? selectedItem[0] : "";
       setInput(v);
       onChange(selectedItem ? selectedItem[0] : undefined);
     },
-    onInputValueChange: ({inputValue: v}) => {
+    onInputValueChange: ({ inputValue: v }) => {
       if (typeof v === "string") {
         setInput(v);
         onChange(v === "" ? undefined : v);
@@ -63,6 +111,35 @@ export default function InputAutocomplete({
       }
     },
   });
+
+  React.useEffect(() => {
+    if (!spriteBaseUrl) {
+      setSpriteSheet(null);
+      return;
+    }
+    let cancelled = false;
+    loadSpriteSheetUrl(spriteBaseUrl).then(
+      (dim) => {
+        if (!cancelled) {
+          setSpriteSheet(dim);
+        }
+      },
+      () => {
+        if (!cancelled) {
+          setSpriteSheet(null);
+        }
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [spriteBaseUrl]);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      setPreviewPointer(null);
+    }
+  }, [isOpen]);
 
   React.useEffect(() => {
     if (isOpen) {
@@ -79,6 +156,49 @@ export default function InputAutocomplete({
     setInput(value || "");
   }, [value]);
 
+  const previewRect =
+    previewPointer && spritePositions
+      ? spritePositions[previewPointer.iconId]
+      : undefined;
+
+  const previewNode =
+    previewPointer && spriteSheet && isValidSpriteRect(previewRect)
+      ? (() => {
+        const scale = Math.min(1, PREVIEW_MAX / Math.max(previewRect.width, previewRect.height));
+        const displayW = Math.max(1, Math.round(previewRect.width * scale));
+        const displayH = Math.max(1, Math.round(previewRect.height * scale));
+        const bgW = spriteSheet.width * scale;
+        const bgH = spriteSheet.height * scale;
+        const outerExtra = 12;
+        let left = previewPointer.clientX + PREVIEW_MARGIN;
+        let top = previewPointer.clientY - displayH - PREVIEW_MARGIN;
+        left = Math.max(
+          PREVIEW_MARGIN,
+          Math.min(left, window.innerWidth - displayW - outerExtra - PREVIEW_MARGIN),
+        );
+        top = Math.max(
+          PREVIEW_MARGIN,
+          Math.min(top, window.innerHeight - displayH - outerExtra - PREVIEW_MARGIN),
+        );
+        return createPortal(
+          <div className="maputnik-sprite-preview" style={{ left, top }} role="presentation">
+            <div
+              className="maputnik-sprite-preview__inner"
+              style={{
+                width: displayW,
+                height: displayH,
+                backgroundImage: `url("${spriteSheet.url}")`,
+                backgroundRepeat: "no-repeat",
+                backgroundSize: `${bgW}px ${bgH}px`,
+                backgroundPosition: `${-previewRect.x * scale}px ${-previewRect.y * scale}px`,
+              }}
+            />
+          </div>,
+          document.body,
+        );
+      })()
+      : null;
+
   return (
     <div className="maputnik-autocomplete">
       <input
@@ -90,27 +210,54 @@ export default function InputAutocomplete({
         })}
       />
       <div
-        {...getMenuProps({}, {suppressRefError: true})}
+        {...getMenuProps({}, { suppressRefError: true })}
         ref={menuRef}
-        style={{position: "fixed", overflow: "auto", maxHeight, zIndex: 998}}
+        style={{ position: "fixed", overflow: "auto", maxHeight, zIndex: 998 }}
         className="maputnik-autocomplete-menu"
       >
         {isOpen &&
-          filteredItems.map((item, index) => (
-            <div
-              key={item[0]}
-              {...getItemProps({
-                item,
-                index,
-                className: classnames("maputnik-autocomplete-menu-item", {
-                  "maputnik-autocomplete-menu-item-selected": highlightedIndex === index,
-                }),
-              })}
-            >
-              {item[1]}
-            </div>
-          ))}
+          filteredItems.map((item, index) => {
+            const iconId = item[0] as string;
+            const baseItemProps = getItemProps({
+              item,
+              index,
+              className: classnames("maputnik-autocomplete-menu-item", {
+                "maputnik-autocomplete-menu-item-selected": highlightedIndex === index,
+              }),
+            }) as React.HTMLAttributes<HTMLDivElement>;
+            return (
+              <div
+                key={iconId}
+                {...baseItemProps}
+                onMouseEnter={(e) => {
+                  baseItemProps.onMouseEnter?.(e);
+                  if (spriteBaseUrl && spritePositions) {
+                    setPreviewPointer({
+                      iconId,
+                      clientX: e.clientX,
+                      clientY: e.clientY,
+                    });
+                  }
+                }}
+                onMouseMove={(e) => {
+                  baseItemProps.onMouseMove?.(e);
+                  setPreviewPointer((p) =>
+                    p && p.iconId === iconId
+                      ? { iconId, clientX: e.clientX, clientY: e.clientY }
+                      : p,
+                  );
+                }}
+                onMouseLeave={(e) => {
+                  baseItemProps.onMouseLeave?.(e);
+                  setPreviewPointer((p) => (p?.iconId === iconId ? null : p));
+                }}
+              >
+                {item[1]}
+              </div>
+            );
+          })}
       </div>
+      {previewNode}
     </div>
   );
 }

--- a/src/components/InputSpec.tsx
+++ b/src/components/InputSpec.tsx
@@ -26,6 +26,8 @@ export type InputSpecProps = {
     values?: unknown[]
     length?: number
     value?: string
+    spriteBaseUrl?: string
+    spritePositions?: Record<string, { width: number; height: number; x: number; y: number; pixelRatio?: number }>
   }
   value?: string | number | unknown[] | boolean
   /** Override the style of the field */
@@ -77,6 +79,8 @@ export default class InputSpec extends React.Component<InputSpecProps> {
           return <InputAutocomplete
             {...commonProps as Omit<InputAutocompleteProps, "options">}
             options={options.map(f => [f, f])}
+            spriteBaseUrl={this.props.fieldSpec.spriteBaseUrl}
+            spritePositions={this.props.fieldSpec.spritePositions}
           />;
         } else {
           return <InputString

--- a/src/components/LayerList.tsx
+++ b/src/components/LayerList.tsx
@@ -20,7 +20,7 @@ import ModalAdd from "./modals/ModalAdd";
 
 import type {LayerSpecification, SourceSpecification} from "maplibre-gl";
 import generateUniqueId from "../libs/document-uid";
-import { findClosestCommonPrefix, layerPrefix } from "../libs/layer";
+import { findClosestCommonPrefix, layerPrefix, remapLayerListCollapsedGroups } from "../libs/layer";
 import { type WithTranslation, withTranslation } from "react-i18next";
 import { type MappedError, type OnMoveLayerCallback } from "../libs/definitions";
 
@@ -193,6 +193,21 @@ class LayerListContainerInternal extends React.Component<LayerListContainerInter
   }
 
   componentDidUpdate (prevProps: LayerListContainerProps) {
+    const layersIdentityChanged =
+      prevProps.layers.length !== this.props.layers.length
+      || prevProps.layers.some((l, i) => l.id !== this.props.layers[i]?.id);
+
+    if (layersIdentityChanged) {
+      const nextCollapsed = remapLayerListCollapsedGroups(
+        prevProps.layers,
+        this.props.layers,
+        this.state.collapsedGroups,
+      );
+      if (!lodash.isEqual(nextCollapsed, this.state.collapsedGroups)) {
+        this.setState({ collapsedGroups: nextCollapsed });
+      }
+    }
+
     if (prevProps.selectedLayerIndex !== this.props.selectedLayerIndex) {
       const selectedItemNode = this.selectedItemRef.current;
       if (selectedItemNode && selectedItemNode.node) {

--- a/src/components/LayerListItem.tsx
+++ b/src/components/LayerListItem.tsx
@@ -1,12 +1,12 @@
-import React from "react";
-import classnames from "classnames";
-import { MdContentCopy, MdVisibility, MdVisibilityOff, MdDelete } from "react-icons/md";
-import { IconContext } from "react-icons";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import classnames from "classnames";
+import React from "react";
+import { IconContext } from "react-icons";
+import { MdContentCopy, MdDelete, MdVisibility, MdVisibilityOff } from "react-icons/md";
 
-import IconLayer from "./IconLayer";
 import type { VisibilitySpecification } from "maplibre-gl";
+import IconLayer from "./IconLayer";
 
 
 type DraggableLabelProps = {
@@ -111,7 +111,7 @@ const LayerListItem = React.forwardRef<HTMLLIElement, LayerListItemProps>((props
     opacity: isDragging ? 0.5 : 1,
   };
 
-  const visibilityAction = visibility === "visible" ? "show" : "hide";
+  const visibilityAction = visibility === "visible" ? "hide" : "show";
 
   // Cast ref to MutableRefObject since we know from the codebase that's what's always passed
   const refObject = ref as React.MutableRefObject<HTMLLIElement | null> | null;

--- a/src/components/PropertyGroup.tsx
+++ b/src/components/PropertyGroup.tsx
@@ -13,9 +13,12 @@ function getFieldSpec(spec: any, layerType: LayerSpecification["type"], fieldNam
   const group = spec[groupName + "_" + layerType];
   const fieldSpec = group[fieldName];
   if(iconProperties.indexOf(fieldName) >= 0) {
+    const rootSprite = spec.$root.sprite || {};
     return {
       ...fieldSpec,
-      values: spec.$root.sprite.values
+      values: rootSprite.values,
+      spriteBaseUrl: rootSprite.spriteBaseUrl,
+      spritePositions: rootSprite.spritePositions,
     };
   }
   if(fieldName === "text-font") {

--- a/src/components/modals/ModalSettings.tsx
+++ b/src/components/modals/ModalSettings.tsx
@@ -146,13 +146,23 @@ class ModalSettingsInternal extends React.Component<ModalSettingsInternalProps> 
           value={(this.props.mapStyle as any).owner}
           onChange={(value) => this.changeStyleProperty("owner", value)}
         />
-        <Block label={t("Sprite URL")} fieldSpec={latest.$root.sprite} data-wd-key="modal:settings.sprite">
-          <FieldJson
-            lintType="json"
-            value={this.props.mapStyle.sprite as any}
+        {Array.isArray(this.props.mapStyle.sprite) ? (
+          <Block label={t("Sprite URL")} fieldSpec={latest.$root.sprite} data-wd-key="modal:settings.sprite">
+            <FieldJson
+              lintType="json"
+              value={this.props.mapStyle.sprite as object}
+              onChange={(value) => this.changeStyleProperty("sprite", value)}
+            />
+          </Block>
+        ) : (
+          <FieldUrl
+            label={t("Sprite URL")}
+            fieldSpec={latest.$root.sprite}
+            data-wd-key="modal:settings.sprite"
+            value={typeof this.props.mapStyle.sprite === "string" ? this.props.mapStyle.sprite : ""}
             onChange={(value) => this.changeStyleProperty("sprite", value)}
           />
-        </Block>
+        )}
 
         <FieldUrl
           label={t("Glyphs URL")}

--- a/src/libs/layer.ts
+++ b/src/libs/layer.ts
@@ -119,14 +119,10 @@ export function isOneIdRemoved(oldIds: string[], newIds: string[]): boolean {
   if (oldIds.length !== newIds.length + 1) {
     return false;
   }
-  let i = 0;
   let j = 0;
-  while (i < oldIds.length && j < newIds.length) {
-    if (oldIds[i] === newIds[j]) {
-      i++;
+  for (let i = 0; i < oldIds.length; i++) {
+    if (j < newIds.length && oldIds[i] === newIds[j]) {
       j++;
-    } else {
-      i++;
     }
   }
   return j === newIds.length;

--- a/src/libs/layer.ts
+++ b/src/libs/layer.ts
@@ -89,3 +89,92 @@ export function findClosestCommonPrefix(layers: LayerSpecification[], idx: numbe
   }
   return closestIdx;
 }
+
+/** Contiguous layer list groups with more than one layer (same prefix), for collapse UI state. */
+export type LayerListGroupRange = {
+  prefix: string
+  start: number
+  end: number
+};
+
+export function getLayerListGroupRanges(layers: LayerSpecification[]): LayerListGroupRange[] {
+  const out: LayerListGroupRange[] = [];
+  let i = 0;
+  while (i < layers.length) {
+    const prefix = layerPrefix(layers[i].id);
+    let j = i + 1;
+    while (j < layers.length && layerPrefix(layers[j].id) === prefix) {
+      j++;
+    }
+    if (j - i > 1) {
+      out.push({ prefix, start: i, end: j });
+    }
+    i = j;
+  }
+  return out;
+}
+
+/** True if newIds is oldIds with exactly one id removed (order preserved). */
+export function isOneIdRemoved(oldIds: string[], newIds: string[]): boolean {
+  if (oldIds.length !== newIds.length + 1) {
+    return false;
+  }
+  let i = 0;
+  let j = 0;
+  while (i < oldIds.length && j < newIds.length) {
+    if (oldIds[i] === newIds[j]) {
+      i++;
+      j++;
+    } else {
+      i++;
+    }
+  }
+  return j === newIds.length;
+}
+
+function idsForGroupRange(layers: LayerSpecification[], range: LayerListGroupRange): string[] {
+  return layers.slice(range.start, range.end).map((l) => l.id);
+}
+
+/**
+ * Re-key layer list collapse state when layers are deleted/reordered so keys stay aligned with
+ * `prefix-startIndex` used by the list UI.
+ */
+export function remapLayerListCollapsedGroups(
+  prevLayers: LayerSpecification[],
+  newLayers: LayerSpecification[],
+  prevCollapsed: Record<string, boolean>,
+): Record<string, boolean> {
+  const oldRanges = getLayerListGroupRanges(prevLayers);
+  const newRanges = getLayerListGroupRanges(newLayers);
+  const next: Record<string, boolean> = {};
+
+  for (const nr of newRanges) {
+    const newIds = idsForGroupRange(newLayers, nr);
+    const newKey = `${nr.prefix}-${nr.start}`;
+
+    let oldMatch = oldRanges.find((or) => {
+      if (or.prefix !== nr.prefix) {
+        return false;
+      }
+      const oldIds = idsForGroupRange(prevLayers, or);
+      return oldIds.join("\0") === newIds.join("\0");
+    });
+
+    if (!oldMatch) {
+      oldMatch = oldRanges.find((or) => {
+        if (or.prefix !== nr.prefix) {
+          return false;
+        }
+        const oldIds = idsForGroupRange(prevLayers, or);
+        return isOneIdRemoved(oldIds, newIds);
+      });
+    }
+
+    if (oldMatch && Object.prototype.hasOwnProperty.call(prevCollapsed, `${oldMatch.prefix}-${oldMatch.start}`)) {
+      next[newKey] = prevCollapsed[`${oldMatch.prefix}-${oldMatch.start}`];
+    }
+  }
+
+  return next;
+}

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -31,9 +31,25 @@ export async function downloadGlyphsMetadata(urlTemplate: string): Promise<strin
   return [...new Set(fonts)];
 }
 
-export async function downloadSpriteMetadata(baseUrl: string): Promise<string[]> {
-  if(!baseUrl) return [];
+export type SpriteIconPosition = {
+  width: number
+  height: number
+  x: number
+  y: number
+  pixelRatio?: number
+};
+
+export type SpriteMetadataResult = {
+  names: string[]
+  positions: Record<string, SpriteIconPosition>
+};
+
+export async function downloadSpriteMetadata(baseUrl: string): Promise<SpriteMetadataResult> {
+  if (!baseUrl) {
+    return { names: [], positions: {} };
+  }
   const url = baseUrl + ".json";
-  const glyphs = await loadJSON(url, {} as Record<string, string>);
-  return Object.keys(glyphs);
+  const json = await loadJSON(url, {} as Record<string, SpriteIconPosition>);
+  const names = Object.keys(json);
+  return { names, positions: json };
 }

--- a/src/styles/_input.scss
+++ b/src/styles/_input.scss
@@ -220,6 +220,29 @@
   }
 }
 
+.maputnik-sprite-preview {
+  position: fixed;
+  z-index: 10050;
+  pointer-events: none;
+  padding: 4px;
+  border: 1px solid vars.$color-midgray;
+  box-sizing: border-box;
+  background-color: vars.$color-black;
+  background-image:
+    linear-gradient(45deg, vars.$color-midgray 25%, transparent 25%),
+    linear-gradient(-45deg, vars.$color-midgray 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, vars.$color-midgray 75%),
+    linear-gradient(-45deg, transparent 75%, vars.$color-midgray 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+
+  &__inner {
+    display: block;
+    image-rendering: pixelated;
+  }
+}
+
 // FONT
 .maputnik-font {
   .maputnik-autocomplete:not(:last-child) {

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -12,8 +12,8 @@
 }
 
 .maputnik-modal {
-  min-width: 350px;
-  max-width: 600px;
+  min-width: 520px;
+  max-width: 820px;
   overflow: hidden;
   background-color: vars.$color-black;
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3);
@@ -316,8 +316,24 @@
   }
 }
 
-.modal-settings {
-  width: 400px;
+/* className="modal:settings" — Style Settings form */
+.modal\:settings {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+
+  /* Default block is 32% / 18% / 50%; shorten label column for long URL fields */
+  .maputnik-input-block-label {
+    width: 24%;
+  }
+
+  .maputnik-input-block-content {
+    width: 58%;
+  }
+
+  .maputnik-action-block .maputnik-input-block-label {
+    width: 24%;
+  }
 }
 
 .maputnik-modal-export-buttons {


### PR DESCRIPTION
## Summary

- **#1675** — The eye button’s `title` (hover tooltip) now matches the action that will run: **Hide** when the layer is visible, **Show** when it is hidden (`LayerListItem`).
- **#1781** — After deleting a layer, expanded prefix-groups stay expanded instead of snapping back to collapsed: collapse state is remapped when the layer list changes (`remapLayerListCollapsedGroups` in `layer.ts`, used from `LayerList`). Deleting a layer also keeps `selectedLayerIndex` / `selectedLayerOriginalId` in range so the list UI does not break (`App`).

## Test plan

- [ ] **#1675** — Add a layer, hover the visibility control: visible layer → tooltip says hide; hidden layer → tooltip says show; click still toggles visibility.
- [ ] **#1781** — Open e.g. OSM Liberty, click **Expand**, delete any layer: groups that were expanded remain expanded; selection remains sensible (no broken / stacked list items).

- Fixes maplibre/maputnik#1675  
- Fixes maplibre/maputnik#1781