### PR TITLE
feat: add drag and drop support to Upload Style area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### 🐞 Bug fixes
 
-- Improved the local style open modal and added Cypress coverage for local file upload.
+- Improved the local style open modal and local file upload.
 - Fixed the Expression editor (for long expressions) being able to be float under other components further down
 - Fixed an issue when clicking on a popup and then clicking on the map again
 - Fix modal close button position

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐞 Bug fixes
 
+- Improved the local style open modal and added Cypress coverage for local file upload.
 - Fixed the Expression editor (for long expressions) being able to be float under other components further down
 - Fixed an issue when clicking on a popup and then clicking on the map again
 - Fix modal close button position

--- a/cypress/e2e/maputnik-cypress-helper.ts
+++ b/cypress/e2e/maputnik-cypress-helper.ts
@@ -43,6 +43,12 @@ export default class MaputnikCypressHelper {
         }
       });
     },
+    dropFileByFixture: (fixture: string, dropzoneTestId: string) => {
+      this.helper.get.elementByTestId(dropzoneTestId).selectFile("cypress/fixtures/" + fixture, {
+        action: "drag-drop",
+        force: true,
+      });
+    },
     ...this.helper.when,
   };
 

--- a/cypress/e2e/maputnik-driver.ts
+++ b/cypress/e2e/maputnik-driver.ts
@@ -146,6 +146,11 @@ export class MaputnikDriver {
       this.helper.when.openFileByFixture("example-style.json", "modal:open.file.button", "modal:open.file.input");
       this.helper.when.wait(200);
     },
+    dropExampleFile: () => {
+      this.helper.given.fixture("example-style.json", "example-style.json");
+      this.helper.when.dropFileByFixture("example-style.json", "modal:open.dropzone");
+      this.helper.when.wait(200);
+    },
     setStyle: (
       styleProperties: "geojson" | "raster" | "both" | "layer" | "rectangles" | "font" | "zoom_7_center_0_51" | "",
       zoom?: number

--- a/cypress/e2e/maputnik-driver.ts
+++ b/cypress/e2e/maputnik-driver.ts
@@ -143,7 +143,7 @@ export class MaputnikDriver {
     },
     chooseExampleFile: () => {
       this.helper.given.fixture("example-style.json", "example-style.json");
-      this.helper.when.openFileByFixture("example-style.json", "modal:open.file.button", "modal:open.file.input");
+      this.helper.when.openFileByFixture("example-style.json", "modal:open.dropzone", "modal:open.file.input");
       this.helper.when.wait(200);
     },
     dropExampleFile: () => {

--- a/cypress/e2e/modals.cy.ts
+++ b/cypress/e2e/modals.cy.ts
@@ -23,6 +23,11 @@ describe("modals", () => {
       then(get.fixture("example-style.json")).shouldEqualToStoredStyle();
     });
 
+    it("upload via drag and drop", () => {
+      when.dropExampleFile();
+      then(get.fixture("example-style.json")).shouldEqualToStoredStyle();
+    });
+
     describe("when click open url", () => {
       beforeEach(() => {
         const styleFileUrl = get.exampleFileUrl();

--- a/src/components/modals/ModalOpen.tsx
+++ b/src/components/modals/ModalOpen.tsx
@@ -276,15 +276,25 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
               onDragLeave={this.onFileDragLeave}
               onDrop={this.onFileDrop}
             >
+              <div className="maputnik-upload-dropzone-content">
+                <MdFileUpload className="maputnik-upload-dropzone-icon" aria-hidden="true" />
+                <p className="maputnik-upload-dropzone-text">
+                  {t("Drag and drop a style JSON file here")}
+                </p>
+                <p className="maputnik-upload-dropzone-subtext">
+                  {t("or click to browse")}
+                </p>
+              </div>
+
               {typeof window.showOpenFilePicker === "function" ? (
                 <InputButton
                   data-wd-key="modal:open.file.button"
-                  className="maputnik-big-button"
+                  className="maputnik-big-button maputnik-upload-dropzone-browse"
                   onClick={this.onOpenFile}><MdFileUpload /> {t("Open Style")}
                 </InputButton>
               ) : (
                 <label>
-                  <a className="maputnik-button maputnik-upload-button" aria-label={t("Open Style")}><MdFileUpload /> {t("Open Style")}</a>
+                  <a className="maputnik-button maputnik-upload-button maputnik-upload-dropzone-browse" aria-label={t("Open Style")}><MdFileUpload /> {t("Open Style")}</a>
                   <input data-wd-key="modal:open.file.input" type="file" style={{ display: "none" }} onChange={(e) => this.onFileChanged(e.target.files)} />
                 </label>
               )}

--- a/src/components/modals/ModalOpen.tsx
+++ b/src/components/modals/ModalOpen.tsx
@@ -58,6 +58,8 @@ type ModalOpenState = {
 };
 
 class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpenState> {
+  private fileInputRef = React.createRef<HTMLInputElement>();
+
   constructor(props: ModalOpenInternalProps) {
     super(props);
     this.state = {
@@ -207,6 +209,15 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
     this.props.onOpenToggle();
   }
 
+  onBrowseClick = async () => {
+    if (typeof window.showOpenFilePicker === "function") {
+      await this.onOpenFile();
+      return;
+    }
+
+    this.fileInputRef.current?.click();
+  };
+
   onFileDragOver = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
@@ -273,32 +284,32 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
             <div
               data-wd-key="modal:open.dropzone"
               className={`maputnik-upload-dropzone${this.state.isDragOver ? " maputnik-upload-dropzone--active" : ""}`}
+              role="button"
+              tabIndex={0}
               onDragOver={this.onFileDragOver}
               onDragLeave={this.onFileDragLeave}
               onDrop={this.onFileDrop}
+              onClick={() => void this.onBrowseClick()}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  void this.onBrowseClick();
+                }
+              }}
             >
               <div className="maputnik-upload-dropzone-content">
                 <MdFileUpload className="maputnik-upload-dropzone-icon" aria-hidden="true" />
                 <p className="maputnik-upload-dropzone-text">
-                  {t("Drag and drop a style JSON file here")}
-                </p>
-                <p className="maputnik-upload-dropzone-subtext">
-                  {t("or click to browse")}
+                  {t("Drag and drop a style JSON file here or click to browse")}
                 </p>
               </div>
-
-              {typeof window.showOpenFilePicker === "function" ? (
-                <InputButton
-                  data-wd-key="modal:open.file.button"
-                  className="maputnik-big-button maputnik-upload-dropzone-browse"
-                  onClick={this.onOpenFile}><MdFileUpload /> {t("Open Style")}
-                </InputButton>
-              ) : (
-                <label>
-                  <a className="maputnik-button maputnik-upload-button maputnik-upload-dropzone-browse" aria-label={t("Open Style")}><MdFileUpload /> {t("Open Style")}</a>
-                  <input data-wd-key="modal:open.file.input" type="file" style={{ display: "none" }} onChange={(e) => this.onFileChanged(e.target.files)} />
-                </label>
-              )}
+              <input
+                ref={this.fileInputRef}
+                data-wd-key="modal:open.file.input"
+                type="file"
+                style={{ display: "none" }}
+                onChange={(e) => this.onFileChanged(e.target.files)}
+              />
             </div>
           </section>
 

--- a/src/components/modals/ModalOpen.tsx
+++ b/src/components/modals/ModalOpen.tsx
@@ -271,6 +271,7 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
             <h1>{t("Open local Style")}</h1>
             <p>{t("Open a local JSON style from your computer.")}</p>
             <div
+              data-wd-key="modal:open.dropzone"
               className={`maputnik-upload-dropzone${this.state.isDragOver ? " maputnik-upload-dropzone--active" : ""}`}
               onDragOver={this.onFileDragOver}
               onDragLeave={this.onFileDragLeave}

--- a/src/components/modals/ModalOpen.tsx
+++ b/src/components/modals/ModalOpen.tsx
@@ -1,4 +1,4 @@
-import React, { type FormEvent } from "react";
+import React, { type DragEvent, type FormEvent } from "react";
 import { MdFileUpload } from "react-icons/md";
 import { MdAddCircleOutline } from "react-icons/md";
 import { Trans, type WithTranslation, withTranslation } from "react-i18next";
@@ -51,6 +51,7 @@ type ModalOpenInternalProps = {
 
 type ModalOpenState = {
   styleUrl: string
+  isDragOver: boolean
   error?: string | null
   activeRequest?: any
   activeRequestUrl?: string | null
@@ -60,7 +61,8 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
   constructor(props: ModalOpenInternalProps) {
     super(props);
     this.state = {
-      styleUrl: ""
+      styleUrl: "",
+      isDragOver: false,
     };
   }
 
@@ -198,11 +200,35 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
 
   onOpenToggle() {
     this.setState({
-      styleUrl: ""
+      styleUrl: "",
+      isDragOver: false,
     });
     this.clearError();
     this.props.onOpenToggle();
   }
+
+  onFileDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!this.state.isDragOver) {
+      this.setState({ isDragOver: true });
+    }
+  };
+
+  onFileDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({ isDragOver: false });
+  };
+
+  onFileDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    this.setState({ isDragOver: false });
+    this.onFileChanged(e.dataTransfer.files);
+  };
 
   onChangeUrl = (url: string) => {
     this.setState({
@@ -244,7 +270,12 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
           <section className="maputnik-modal-section">
             <h1>{t("Open local Style")}</h1>
             <p>{t("Open a local JSON style from your computer.")}</p>
-            <div>
+            <div
+              className={`maputnik-upload-dropzone${this.state.isDragOver ? " maputnik-upload-dropzone--active" : ""}`}
+              onDragOver={this.onFileDragOver}
+              onDragLeave={this.onFileDragLeave}
+              onDrop={this.onFileDrop}
+            >
               {typeof window.showOpenFilePicker === "function" ? (
                 <InputButton
                   data-wd-key="modal:open.file.button"

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -199,6 +199,6 @@
   "Video URL": "Video-URL",
   "View": "Ansicht",
   "You've entered an old style filter.": "Du hast einen alten Filter-Stil eingegeben.",
-  "Zoom": "Zoom"
-  ,"Drag and drop a style JSON file here or click to browse": "__STRING_NOT_TRANSLATED__"
-    "Drag and drop a style JSON file here or click to browse": "Ziehen Sie eine Style-JSON-Datei hierher oder klicken Sie, um zu durchsuchen"
+  "Zoom": "Zoom",
+  "Drag and drop a style JSON file here or click to browse": "Ziehen Sie eine Style-JSON-Datei hierher oder klicken Sie, um zu durchsuchen"
+}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -200,4 +200,5 @@
   "View": "Ansicht",
   "You've entered an old style filter.": "Du hast einen alten Filter-Stil eingegeben.",
   "Zoom": "Zoom"
-}
+  ,"Drag and drop a style JSON file here or click to browse": "__STRING_NOT_TRANSLATED__"
+    "Drag and drop a style JSON file here or click to browse": "Ziehen Sie eine Style-JSON-Datei hierher oder klicken Sie, um zu durchsuchen"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,3 @@
+{
+  "Drag and drop a style JSON file here or click to browse": "Drag and drop a style JSON file here or click to browse"
+}

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -199,5 +199,6 @@
   "Video URL": "URL de la vidéo",
   "View": "Vue",
   "You've entered an old style filter.": "Vous avez entré un ancien style de filtre.",
-  "Zoom": "Zoom"
+  "Zoom": "Zoom",
+  "Drag and drop a style JSON file here or click to browse": "Faites glisser un fichier JSON de style ici ou cliquez pour parcourir"
 }

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -199,5 +199,6 @@
   "Video URL": "כתובת וידאו",
   "View": "תצוגה",
   "You've entered an old style filter.": "הכנסתם סינון מסוג ישן,",
-  "Zoom": "זום"
+  "Zoom": "זום",
+  "Drag and drop a style JSON file here or click to browse": "גרור ושחרר כאן קובץ JSON של סגנון או לחץ כדי לעיין"
 }

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -199,5 +199,6 @@
   "Video URL": "Indirizzo video",
   "View": "Vista",
   "You've entered an old style filter.": "Hai inserito uno stile filtro obsoleto.",
-  "Zoom": "Zoom"
+  "Zoom": "Zoom",
+  "Drag and drop a style JSON file here or click to browse": "Trascina e rilascia qui un file JSON dello stile o fai clic per sfogliare"
 }

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -199,5 +199,6 @@
   "Video URL": "動画URL",
   "View": "表示",
   "You've entered an old style filter.": "旧型フィルタを使用しております。",
-  "Zoom": "ズーム"
+  "Zoom": "ズーム",
+  "Drag and drop a style JSON file here or click to browse": "ここにスタイルのJSONファイルをドラッグ＆ドロップするか、クリックして参照してください"
 }

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -199,5 +199,6 @@
   "Video URL": "비디오 URL",
   "View": "보기",
   "You've entered an old style filter.": "이전 스타일 필터를 입력했습니다.",
-  "Zoom": "줌"
+  "Zoom": "줌",
+  "Drag and drop a style JSON file here or click to browse": "여기에 스타일 JSON 파일을 끌어다 놓거나 클릭하여 찾아보세요"
 }

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -199,5 +199,6 @@
   "Video URL": "视频URL",
   "View": "视图",
   "You've entered an old style filter.": "您输入了一个旧风格的过滤器。",
-  "Zoom": "缩放"
+  "Zoom": "缩放",
+  "Drag and drop a style JSON file here or click to browse": "将样式 JSON 文件拖放到此处或点击以浏览"
 }

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -88,6 +88,17 @@
   @extend .maputnik-big-button !optional; /* stylelint-disable-line */
 }
 
+.maputnik-upload-dropzone {
+  border: 1px dashed transparent;
+  border-radius: 4px;
+  padding: vars.$margin-1;
+}
+
+.maputnik-upload-dropzone--active {
+  border-color: vars.$color-midgray;
+  background-color: vars.$color-gray;
+}
+
 .maputnik-style-gallery-container {
   flex-shrink: 1;
 }

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -93,6 +93,19 @@
   border-radius: 6px;
   padding: vars.$margin-4 vars.$margin-3;
   text-align: center;
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: vars.$color-lowgray;
+    background-color: rgba(255, 255, 255, 0.03);
+  }
+
+  &:focus-visible {
+    outline: 2px solid vars.$color-lowgray;
+    outline-offset: 2px;
+  }
 }
 
 .maputnik-upload-dropzone--active {
@@ -114,15 +127,6 @@
 .maputnik-upload-dropzone-text {
   margin: vars.$margin-2 0 0;
   color: vars.$color-lowgray;
-}
-
-.maputnik-upload-dropzone-subtext {
-  margin: vars.$margin-1 0 vars.$margin-2;
-  color: vars.$color-midgray;
-}
-
-.maputnik-upload-dropzone-browse {
-  margin-top: vars.$margin-2;
 }
 
 .maputnik-style-gallery-container {

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -89,14 +89,40 @@
 }
 
 .maputnik-upload-dropzone {
-  border: 1px dashed transparent;
-  border-radius: 4px;
-  padding: vars.$margin-1;
+  border: 2px dashed vars.$color-midgray;
+  border-radius: 6px;
+  padding: vars.$margin-4 vars.$margin-3;
+  text-align: center;
 }
 
 .maputnik-upload-dropzone--active {
-  border-color: vars.$color-midgray;
-  background-color: vars.$color-gray;
+  border-color: vars.$color-lowgray;
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.maputnik-upload-dropzone-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.maputnik-upload-dropzone-icon {
+  font-size: 28px;
+  color: vars.$color-midgray;
+}
+
+.maputnik-upload-dropzone-text {
+  margin: vars.$margin-2 0 0;
+  color: vars.$color-lowgray;
+}
+
+.maputnik-upload-dropzone-subtext {
+  margin: vars.$margin-1 0 vars.$margin-2;
+  color: vars.$color-midgray;
+}
+
+.maputnik-upload-dropzone-browse {
+  margin-top: vars.$margin-2;
 }
 
 .maputnik-style-gallery-container {


### PR DESCRIPTION
## Feat: Add drag and drop support to Upload Style area

Closes #911

---

### Problem
The Upload Style area only supported click-to-upload. Users could not drag and drop a JSON file directly onto it.

### Fix
Added `onDragOver` and `onDrop` event handlers to the Upload Style area. The dropped file is passed to the existing file reading logic already used by the Upload button. A visual highlight is shown when dragging over the area.
