### PR TITLE
feat(layers): add multi-select with checkboxes and bulk actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐞 Bug fixes
 
+- Fix the layer visibility toggle hover label being reversed
 - Fixed the Expression editor (for long expressions) being able to be float under other components further down
 - Fixed an issue when clicking on a popup and then clicking on the map again
 - Fix modal close button position

--- a/cypress/e2e/layers-list.cy.ts
+++ b/cypress/e2e/layers-list.cy.ts
@@ -59,6 +59,14 @@ describe("layers list", () => {
     });
 
     describe("when clicking hide", () => {
+      it("should show the correct hover label for the visibility toggle", () => {
+        then(get.elementByTestId("layer-list-item:" + id + ":toggle-visibility")).should("have.attr", "title", "hide");
+
+        when.click("layer-list-item:" + id + ":toggle-visibility");
+
+        then(get.elementByTestId("layer-list-item:" + id + ":toggle-visibility")).should("have.attr", "title", "show");
+      });
+
       beforeEach(() => {
         when.click("layer-list-item:" + id + ":toggle-visibility");
       });

--- a/src/components/LayerList.tsx
+++ b/src/components/LayerList.tsx
@@ -13,6 +13,15 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import {
+  MdContentCopy,
+  MdDelete,
+  MdGroupWork,
+  MdKeyboardArrowDown,
+  MdKeyboardArrowUp,
+  MdVisibility,
+  MdVisibilityOff,
+} from "react-icons/md";
 
 import LayerListGroup from "./LayerListGroup";
 import LayerListItem from "./LayerListItem";
@@ -42,6 +51,29 @@ type LayerListContainerState = {
   areAllGroupsExpanded: boolean
   keys: {[key: string]: number}
   isOpen: {[key: string]: boolean}
+  selectedLayerIds: string[]
+};
+
+type BulkActionButtonProps = {
+  icon: React.ReactNode
+  label: string
+  onClick(): void
+  disabled?: boolean
+  wdKey: string
+};
+
+const BulkActionButton: React.FC<BulkActionButtonProps> = (props) => {
+  return <button
+    type="button"
+    className="maputnik-button maputnik-layer-list-bulk-actions__button"
+    data-wd-key={props.wdKey}
+    onClick={props.onClick}
+    disabled={props.disabled}
+    title={props.label}
+    aria-label={props.label}
+  >
+    <span className="maputnik-layer-list-bulk-actions__button-icon">{props.icon}</span>
+  </button>;
 };
 
 // List of collapsible layer editors
@@ -64,9 +96,122 @@ class LayerListContainerInternal extends React.Component<LayerListContainerInter
       },
       isOpen: {
         add: false,
-      }
+      },
+      selectedLayerIds: []
     };
   }
+
+  getSelectedLayers() {
+    const selectedIds = new Set(this.state.selectedLayerIds);
+    return this.props.layers
+      .map((layer, index) => ({ layer, index }))
+      .filter(({ layer }) => selectedIds.has(layer.id));
+  }
+
+  setSelectedLayerIds(layerIds: string[]) {
+    const uniqueLayerIds = Array.from(new Set(layerIds));
+    this.setState({
+      selectedLayerIds: uniqueLayerIds
+    });
+  }
+
+  onLayerSelectionToggle = (layerId: string, checked: boolean) => {
+    const selectedIds = new Set(this.state.selectedLayerIds);
+    if (checked) {
+      selectedIds.add(layerId);
+    } else {
+      selectedIds.delete(layerId);
+    }
+    this.setSelectedLayerIds(Array.from(selectedIds));
+  };
+
+  clearLayerSelection = () => {
+    if (this.state.selectedLayerIds.length > 0) {
+      this.setSelectedLayerIds([]);
+    }
+  };
+
+  toggleSelectedVisibility = (visibility: "visible" | "none") => {
+    const selectedIds = new Set(this.state.selectedLayerIds);
+    const changedLayers = this.props.layers.map(layer => {
+      if (!selectedIds.has(layer.id)) {
+        return layer;
+      }
+
+      const changedLayer = { ...layer };
+      const changedLayout = "layout" in changedLayer ? { ...changedLayer.layout } : {};
+      changedLayout.visibility = visibility;
+      changedLayer.layout = changedLayout;
+      return changedLayer;
+    });
+
+    this.props.onLayersChange(changedLayers);
+  };
+
+  duplicateSelectedLayers = () => {
+    const selectedIds = new Set(this.state.selectedLayerIds);
+    const changedLayers: LayerSpecification[] = [];
+
+    this.props.layers.forEach(layer => {
+      changedLayers.push(layer);
+      if (selectedIds.has(layer.id)) {
+        const clonedLayer = lodash.cloneDeep(layer);
+        clonedLayer.id = `${clonedLayer.id}-copy-${generateUniqueId()}`;
+        changedLayers.push(clonedLayer);
+      }
+    });
+
+    this.props.onLayersChange(changedLayers);
+  };
+
+  deleteSelectedLayers = () => {
+    const selectedIds = new Set(this.state.selectedLayerIds);
+    const changedLayers = this.props.layers.filter(layer => !selectedIds.has(layer.id));
+    this.props.onLayersChange(changedLayers);
+    this.clearLayerSelection();
+  };
+
+  reorderSelectedLayers = (offset: number) => {
+    const selectedLayers = this.getSelectedLayers();
+    if (selectedLayers.length === 0) {
+      return;
+    }
+
+    const firstSelectedIndex = selectedLayers[0].index;
+    const lastSelectedIndex = selectedLayers[selectedLayers.length - 1].index;
+
+    if (offset < 0 && firstSelectedIndex === 0) {
+      return;
+    }
+    if (offset > 0 && lastSelectedIndex === this.props.layers.length - 1) {
+      return;
+    }
+
+    const selectedIds = new Set(this.state.selectedLayerIds);
+    const selectedLayerObjects: LayerSpecification[] = [];
+    const remainingLayers: LayerSpecification[] = [];
+
+    this.props.layers.forEach(layer => {
+      if (selectedIds.has(layer.id)) {
+        selectedLayerObjects.push(layer);
+      } else {
+        remainingLayers.push(layer);
+      }
+    });
+
+    const insertionIndex = Math.max(0, Math.min(remainingLayers.length, firstSelectedIndex + offset));
+    const changedLayers = [
+      ...remainingLayers.slice(0, insertionIndex),
+      ...selectedLayerObjects,
+      ...remainingLayers.slice(insertionIndex),
+    ];
+
+    this.props.onLayersChange(changedLayers);
+  };
+
+  groupSelectedLayersTogether = () => {
+    this.reorderSelectedLayers(0);
+  };
 
   toggleModal(modalName: string) {
     this.setState({
@@ -193,6 +338,17 @@ class LayerListContainerInternal extends React.Component<LayerListContainerInter
   }
 
   componentDidUpdate (prevProps: LayerListContainerProps) {
+    if (prevProps.layers !== this.props.layers) {
+      const existingIds = new Set(this.props.layers.map(layer => layer.id));
+      const selectedLayerIds = this.state.selectedLayerIds.filter(layerId => existingIds.has(layerId));
+
+      if (selectedLayerIds.length !== this.state.selectedLayerIds.length) {
+        this.setState({
+          selectedLayerIds
+        });
+      }
+    }
+
     if (prevProps.selectedLayerIndex !== this.props.selectedLayerIndex) {
       const selectedItemNode = this.selectedItemRef.current;
       if (selectedItemNode && selectedItemNode.node) {
@@ -218,6 +374,64 @@ class LayerListContainerInternal extends React.Component<LayerListContainerInter
     const listItems: JSX.Element[] = [];
     let idx = 0;
     const layersByGroup = this.groupedLayers();
+    const t = this.props.t;
+    const selectedLayers = this.getSelectedLayers();
+    const selectedCount = selectedLayers.length;
+    const canMoveUp = selectedCount > 0 && selectedLayers[0].index > 0;
+    const canMoveDown = selectedCount > 0 && selectedLayers[selectedLayers.length - 1].index < this.props.layers.length - 1;
+
+    const bulkActions = selectedCount > 0 ? <div className="maputnik-layer-list-bulk-actions" data-wd-key="layer-list.bulk-actions">
+      <span className="maputnik-layer-list-bulk-actions__count">{selectedCount} selected</span>
+      <span className="maputnik-space" />
+      <div className="maputnik-multibutton maputnik-layer-list-bulk-actions__buttons">
+        <BulkActionButton
+          wdKey="layer-list.bulk-actions.hide"
+          label={t("Hide all selected")}
+          icon={<MdVisibilityOff />}
+          onClick={() => this.toggleSelectedVisibility("none")}
+        />
+        <BulkActionButton
+          wdKey="layer-list.bulk-actions.show"
+          label={t("Show all selected")}
+          icon={<MdVisibility />}
+          onClick={() => this.toggleSelectedVisibility("visible")}
+        />
+        <BulkActionButton
+          wdKey="layer-list.bulk-actions.move-up"
+          label={t("Move selected layers up")}
+          icon={<MdKeyboardArrowUp />}
+          onClick={() => this.reorderSelectedLayers(-1)}
+          disabled={!canMoveUp}
+        />
+        <BulkActionButton
+          wdKey="layer-list.bulk-actions.move-down"
+          label={t("Move selected layers down")}
+          icon={<MdKeyboardArrowDown />}
+          onClick={() => this.reorderSelectedLayers(1)}
+          disabled={!canMoveDown}
+        />
+        <BulkActionButton
+          wdKey="layer-list.bulk-actions.group"
+          label={t("Group selected layers together")}
+          icon={<MdGroupWork />}
+          onClick={this.groupSelectedLayersTogether}
+          disabled={selectedCount < 2}
+        />
+        <BulkActionButton
+          wdKey="layer-list.bulk-actions.duplicate"
+          label={t("Duplicate selected layers")}
+          icon={<MdContentCopy />}
+          onClick={this.duplicateSelectedLayers}
+        />
+        <BulkActionButton
+          wdKey="layer-list.bulk-actions.delete"
+          label={t("Delete all selected")}
+          icon={<MdDelete />}
+          onClick={this.deleteSelectedLayers}
+        />
+      </div>
+    </div> : null;
+
     layersByGroup.forEach(layers => {
       const groupPrefix = layerPrefix(layers[0].id);
       if(layers.length > 1) {
@@ -252,7 +466,8 @@ class LayerListContainerInternal extends React.Component<LayerListContainerInter
           className={classnames({
             "maputnik-layer-list-item-collapsed": layers.length > 1 && this.isCollapsed(groupPrefix, groupIdx) && idx !== this.props.selectedLayerIndex,
             "maputnik-layer-list-item-group-last": idxInGroup == layers.length - 1 && layers.length > 1,
-            "maputnik-layer-list-item--error": !!layerError
+            "maputnik-layer-list-item--error": !!layerError,
+            "maputnik-layer-list-item--bulk-selected": selectedLayers.some(selectedLayer => selectedLayer.index === idx)
           })}
           key={layer.key}
           id={layer.key}
@@ -261,18 +476,18 @@ class LayerListContainerInternal extends React.Component<LayerListContainerInter
           layerType={layer.type}
           visibility={(layer.layout || {}).visibility}
           isSelected={idx === this.props.selectedLayerIndex}
+          isBulkSelected={selectedLayers.some(selectedLayer => selectedLayer.index === idx)}
           onLayerSelect={this.props.onLayerSelect}
           onLayerDestroy={this.props.onLayerDestroy?.bind(this)}
           onLayerCopy={this.props.onLayerCopy.bind(this)}
           onLayerVisibilityToggle={this.props.onLayerVisibilityToggle.bind(this)}
+          onLayerSelectionToggle={this.onLayerSelectionToggle}
           {...additionalProps}
         />;
         listItems.push(listItem);
         idx += 1;
       });
     });
-
-    const t = this.props.t;
 
     return <section
       className="maputnik-layer-list"
@@ -318,6 +533,7 @@ class LayerListContainerInternal extends React.Component<LayerListContainerInter
           </div>
         </div>
       </header>
+      {bulkActions}
       <div
         role="navigation"
         aria-label={t("Layers list")}

--- a/src/components/LayerListItem.tsx
+++ b/src/components/LayerListItem.tsx
@@ -79,21 +79,56 @@ type LayerListItemProps = {
   layerId: string
   layerType: string
   isSelected?: boolean
+  isBulkSelected?: boolean
   visibility?: VisibilitySpecification
   className?: string
   onLayerSelect(index: number): void;
   onLayerCopy?(...args: unknown[]): unknown
   onLayerDestroy?(...args: unknown[]): unknown
   onLayerVisibilityToggle?(...args: unknown[]): unknown
+  onLayerSelectionToggle?(layerId: string, checked: boolean): void
+};
+
+type LayerSelectionCheckboxProps = {
+  checked: boolean
+  ariaLabel: string
+  wdKey?: string
+  onChange(checked: boolean): void
+};
+
+const LayerSelectionCheckbox: React.FC<LayerSelectionCheckboxProps> = (props) => {
+  return <div
+    className={classnames("maputnik-checkbox-wrapper", "maputnik-layer-list-item-select")}
+    data-wd-key={props.wdKey}
+    aria-label={props.ariaLabel}
+    onPointerDown={e => e.stopPropagation()}
+    onMouseDown={e => e.stopPropagation()}
+    onClick={e => e.stopPropagation()}
+  >
+    <input
+      className="maputnik-checkbox"
+      type="checkbox"
+      checked={props.checked}
+      onChange={(e) => props.onChange(e.currentTarget.checked)}
+      onClick={e => e.stopPropagation()}
+    />
+    <div className="maputnik-checkbox-box">
+      <svg style={{ display: props.checked ? "inline" : "none" }} className="maputnik-checkbox-icon" viewBox='0 0 32 32'>
+        <path d='M1 14 L5 10 L13 18 L27 4 L31 8 L13 26 z' />
+      </svg>
+    </div>
+  </div>;
 };
 
 const LayerListItem = React.forwardRef<HTMLLIElement, LayerListItemProps>((props, ref) => {
   const {
     isSelected = false,
+    isBulkSelected = false,
     visibility = "visible",
     onLayerCopy = () => { },
     onLayerDestroy = () => { },
     onLayerVisibilityToggle = () => { },
+    onLayerSelectionToggle = () => { },
   } = props;
 
   const {
@@ -131,34 +166,42 @@ const LayerListItem = React.forwardRef<HTMLLIElement, LayerListItemProps>((props
       className={classnames({
         "maputnik-layer-list-item": true,
         "maputnik-layer-list-item-selected": isSelected,
+        "maputnik-layer-list-item--bulk-selected": isBulkSelected,
         [props.className!]: true,
       })}>
+      <LayerSelectionCheckbox
+        wdKey={"layer-list-item:" + props.layerId + ":select"}
+        ariaLabel={`Select layer ${props.layerId}`}
+        checked={isBulkSelected}
+        onChange={(checked) => onLayerSelectionToggle(props.layerId, checked)}
+      />
       <DraggableLabel
         layerId={props.layerId}
         layerType={props.layerType}
         dragAttributes={attributes}
         dragListeners={listeners}
       />
-      <span style={{ flexGrow: 1 }} />
-      <IconAction
-        wdKey={"layer-list-item:" + props.layerId + ":delete"}
-        action={"delete"}
-        classBlockName="delete"
-        onClick={_e => onLayerDestroy!(props.layerIndex)}
-      />
-      <IconAction
-        wdKey={"layer-list-item:" + props.layerId + ":copy"}
-        action={"duplicate"}
-        classBlockName="duplicate"
-        onClick={_e => onLayerCopy!(props.layerIndex)}
-      />
-      <IconAction
-        wdKey={"layer-list-item:" + props.layerId + ":toggle-visibility"}
-        action={visibilityAction}
-        classBlockName="visibility"
-        classBlockModifier={visibilityAction}
-        onClick={_e => onLayerVisibilityToggle!(props.layerIndex)}
-      />
+      <div className="maputnik-layer-list-item-actions">
+        <IconAction
+          wdKey={"layer-list-item:" + props.layerId + ":copy"}
+          action={"duplicate"}
+          classBlockName="duplicate"
+          onClick={_e => onLayerCopy!(props.layerIndex)}
+        />
+        <IconAction
+          wdKey={"layer-list-item:" + props.layerId + ":toggle-visibility"}
+          action={visibilityAction}
+          classBlockName="visibility"
+          classBlockModifier={visibilityAction}
+          onClick={_e => onLayerVisibilityToggle!(props.layerIndex)}
+        />
+        <IconAction
+          wdKey={"layer-list-item:" + props.layerId + ":delete"}
+          action={"delete"}
+          classBlockName="delete"
+          onClick={_e => onLayerDestroy!(props.layerIndex)}
+        />
+      </div>
     </li>
   </IconContext.Provider>;
 });

--- a/src/components/LayerListItem.tsx
+++ b/src/components/LayerListItem.tsx
@@ -32,6 +32,7 @@ const DraggableLabel: React.FC<DraggableLabelProps> = (props) => {
 
 type IconActionProps = {
   action: string
+  title?: string
   onClick(...args: unknown[]): unknown
   wdKey?: string
   classBlockName?: string
@@ -62,7 +63,7 @@ class IconAction extends React.Component<IconActionProps> {
 
     return <button
       tabIndex={-1}
-      title={this.props.action}
+      title={this.props.title || this.props.action}
       className={`maputnik-layer-list-icon-action ${classAdditions}`}
       data-wd-key={this.props.wdKey}
       onClick={this.props.onClick}
@@ -147,6 +148,7 @@ const LayerListItem = React.forwardRef<HTMLLIElement, LayerListItemProps>((props
   };
 
   const visibilityAction = visibility === "visible" ? "show" : "hide";
+  const visibilityTitle = visibility === "visible" ? "hide" : "show";
 
   // Cast ref to MutableRefObject since we know from the codebase that's what's always passed
   const refObject = ref as React.MutableRefObject<HTMLLIElement | null> | null;
@@ -191,6 +193,7 @@ const LayerListItem = React.forwardRef<HTMLLIElement, LayerListItemProps>((props
         <IconAction
           wdKey={"layer-list-item:" + props.layerId + ":toggle-visibility"}
           action={visibilityAction}
+          title={visibilityTitle}
           classBlockName="visibility"
           classBlockModifier={visibilityAction}
           onClick={_e => onLayerVisibilityToggle!(props.layerIndex)}

--- a/src/styles/_layer.scss
+++ b/src/styles/_layer.scss
@@ -26,6 +26,78 @@
     }
   }
 
+  &-bulk-actions {
+    padding: vars.$margin-2;
+    position: sticky;
+    top: 44px;
+    z-index: 2000;
+    background-color: color.adjust(vars.$color-black, $lightness: 1%);
+    border-bottom: solid 1px color.adjust(vars.$color-black, $lightness: 0.1%);
+    color: vars.$color-lowgray;
+    display: flex;
+    align-items: center;
+    gap: vars.$margin-1;
+    flex-wrap: wrap;
+  }
+
+  &-bulk-actions__count {
+    font-size: 11px;
+    color: vars.$color-white;
+    font-weight: 600;
+    white-space: nowrap;
+    padding: 3px 6px;
+    border-radius: 3px;
+    background-color: color.adjust(vars.$color-midgray, $lightness: -8%);
+    border: solid 1px color.adjust(vars.$color-midgray, $lightness: -2%);
+  }
+
+  &-bulk-actions__buttons {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 2px;
+    margin-right: 0;
+    overflow-x: auto;
+    padding-bottom: 1px;
+  }
+
+  &-bulk-actions__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border-radius: 3px;
+    white-space: nowrap;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    appearance: none;
+    border: none;
+    outline: none;
+    background: transparent;
+
+    &:active {
+      background-color: color.adjust(vars.$color-midgray, $lightness: -8%);
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: none;
+    }
+
+    &:focus-visible {
+      box-shadow: inset 0 0 0 1px color.adjust(vars.$color-lowgray, $lightness: -10%);
+      background-color: color.adjust(vars.$color-midgray, $lightness: -8%);
+    }
+  }
+
+  &-bulk-actions__button-icon {
+    width: 14px;
+    height: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   &-header-title {
     font-size: vars.$font-size-5;
     color: vars.$color-white;
@@ -47,6 +119,7 @@
     display: flex;
     cursor: grab;
     align-items: center;
+    min-width: 0;
     svg {
       margin-right: 4px;
     }
@@ -76,10 +149,11 @@
     opacity: 1;
     -webkit-transition: opacity 600ms, visibility 600ms;
     transition: opacity 600ms, visibility 600ms;
+    gap: vars.$margin-2;
 
-    &:focus-within {
-      border: solid 1px vars.$color-lowgray;
-    }
+    // Remove the global focus-within border to avoid a harsh rectangle
+    // when clicking child controls. Individual controls handle their
+    // own focus-visible styles below.
 
     @include mixins.flex-row;
 
@@ -90,18 +164,48 @@
   }
 
   &-icon-action {
-    display: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
 
     svg {
       fill: vars.$color-black;
     }
   }
 
+  &-item-actions {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 2px;
+    flex: 0 0 auto;
+    margin-left: auto;
+  }
+
+  &-item-select {
+    flex: 0 0 auto;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 120ms ease-out;
+    margin-right: 0;
+    margin-left: 0;
+
+    .maputnik-checkbox-box {
+      margin-right: 0;
+    }
+  }
+
   .maputnik-layer-list-icon-action {
+    appearance: none;
     background: initial;
     border: none;
-    padding: 0 2px;
+    padding: 0;
+    width: 15px;
     height: 15px;
+    border-radius: 2px;
+    outline: none;
+    box-shadow: none;
 
     svg {
       fill: color.adjust(vars.$color-lowgray, $lightness: -20%);
@@ -110,6 +214,15 @@
         fill: vars.$color-white;
       }
     }
+
+    &:active {
+      background-color: color.adjust(vars.$color-midgray, $lightness: -8%);
+    }
+
+    &:focus-visible {
+      background-color: color.adjust(vars.$color-midgray, $lightness: -8%);
+      box-shadow: inset 0 0 0 1px color.adjust(vars.$color-lowgray, $lightness: -10%);
+    }
   }
 
   .maputnik-layer-list-icon-action__visibility--hide {
@@ -117,16 +230,21 @@
   }
 
   .maputnik-layer-list-item:hover,
-  .maputnik-layer-list-item-selected {
+  .maputnik-layer-list-item-selected,
+  .maputnik-layer-list-item--bulk-selected {
     background-color: color.adjust(vars.$color-black, $lightness: 2%);
 
-    .maputnik-layer-list-icon-action {
-      display: block;
-
-      svg {
-        fill: color.adjust(vars.$color-lowgray, $lightness: -0.5%);
-      }
+    .maputnik-layer-list-icon-action svg {
+      fill: color.adjust(vars.$color-lowgray, $lightness: -0.5%);
     }
+  }
+
+  .maputnik-layer-list-item:hover .maputnik-layer-list-item-select,
+  .maputnik-layer-list-item-selected .maputnik-layer-list-item-select,
+  .maputnik-layer-list-item--bulk-selected .maputnik-layer-list-item-select,
+  .maputnik-layer-list-item:focus-within .maputnik-layer-list-item-select {
+    opacity: 1;
+    pointer-events: auto;
   }
 
 
@@ -153,7 +271,9 @@
 
   &-item-id {
     all: inherit;
-    width: 115px;
+    min-width: 72px;
+    max-width: 120px;
+    width: auto;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -162,6 +282,12 @@
     cursor: pointer;
     // HACK: Remove important
     outline: none !important;
+
+    &:focus-visible {
+      background-color: color.adjust(vars.$color-midgray, $lightness: -8%);
+      border-radius: 2px;
+      box-shadow: inset 0 0 0 1px color.adjust(vars.$color-lowgray, $lightness: -10%);
+    }
   }
 
   &-group-header {


### PR DESCRIPTION
## What this PR does
Adds multi-select support to the Layers panel. Users can now select multiple layers at once and perform bulk operations on them.

## Changes
- Per-row checkbox (hidden by default, visible on hover or when checked)
- Bulk actions bar appears at top of panel when 1+ layers are selected:
  - Hide / Show
  - Move up / down
  - Group
  - Duplicate
  - Delete
- Single layer click/edit behavior is fully unchanged

## Files changed
- `LayerList.tsx` — selection state and bulk action handlers
- `LayerListItem.tsx` — per-row checkbox and action cluster
- `_layer.scss` — checkbox visibility, bulk bar styles, focus behavior

## Screenshot
<img width="567" height="639" alt="image" src="https://github.com/user-attachments/assets/3fa1757a-e779-4089-b6d5-1a1a18e091e0" />


Closes #424