### PR TITLE
Fix blank map when a style arrives before `style.load` fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix blank map when a style reaches the map component before `style.load` fires — the style was silently dropped and the map kept rendering the empty default style
 - _...Add new stuff here..._
 
 ## 3.1.0

--- a/src/components/MapMaplibreGl.tsx
+++ b/src/components/MapMaplibreGl.tsx
@@ -88,6 +88,9 @@ class MapMaplibreGlInternal extends React.Component<MapMaplibreGlInternalProps, 
     options: {} as MapOptions,
   };
   container: HTMLDivElement | null = null;
+  // Held from map creation, unlike state.map which is only set once "style.load"
+  // fires. A style arriving before that event must still reach the map.
+  map: Map | null = null;
 
   constructor(props: MapMaplibreGlInternalProps) {
     super(props);
@@ -114,7 +117,7 @@ class MapMaplibreGlInternal extends React.Component<MapMaplibreGlInternalProps, 
   }
 
   componentDidUpdate() {
-    const map = this.state.map;
+    const map = this.map;
 
     const styleWithTokens = this.props.replaceAccessTokens(this.props.mapStyle);
     if (map) {
@@ -169,6 +172,7 @@ class MapMaplibreGlInternal extends React.Component<MapMaplibreGlInternalProps, 
     const protocol = new Protocol({metadata: true});
     MapLibreGl.addProtocol("pmtiles",protocol.tile);
     const map = new MapLibreGl.Map(mapOpts);
+    this.map = map;
 
     const mapViewChange = () => {
       const center = map.getCenter();


### PR DESCRIPTION
The map instance is only put into state from the "style.load" handler, and componentDidUpdate - the only place that pushes a style into the map - gates on it. If a style reaches props before that event fires, setStyle is skipped and the style is lost.

It is never retried: the setState from "style.load" cannot trigger componentDidUpdate, because shouldComponentUpdate compares via JSON.stringify(this.state), which throws on the circular Map instance. The catch swallows it and `should` stays false. The map is stuck on the empty default style while every panel shows the real one.

Hold the map in an instance field assigned right after creation, so the style is delivered regardless of "style.load". Calling setStyle() before the initial style has loaded is safe - Map._updateDiff() catches "Style is not done loading" from style.setState() and falls back to a full _updateStyle().

This does not reproduce on maputnik.org or in the e2e suite, because both load the style over the network via ?style=<url>, which always takes long enough for "style.load" to win. It shows up when the style comes from localStorage, which StyleStore.getLatestStyle() resolves in a microtask.

To reproduce: seed a style into `localStorage` (`maputnik:style:<id>` plus `maputnik:latest_style`) so `StyleStore` picks it up without a network fetch, then load Maputnik with no `?style=` param and reload a few times. In Firefox the map is blank almost every time, in Chrome roughly 1 in 10. The layer list shows the style either way.

## Launch Checklist

 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.

I left the test box unchecked on purpose, because I'm not sure what you'd want and would rather ask first.

An e2e test would be flaky - it's a timing race, so seeding localStorage and reloading fails nearly every time in Firefox but only about 1 in 10 in Chromium. A component test would be deterministic (mock the Map, never fire `style.load`, change the `mapStyle` prop, assert `setStyle` was called), but I couldn't find component test infra to hang it on: vitest runs `src/**/*.test.{ts,tsx}` in the node env and there's no jsdom or `@vitest/browser` in package.json. The `## main` changelog mentions Vitest browser mode for component tests, so maybe that's already on its way?

Happy to write either one once you tell me which.

We've been running this patch on v3.1.0 in production for a few days now, no regressions so far.

